### PR TITLE
Hide Polyfill internal usage

### DIFF
--- a/src/CliInvoke.Core/Builders/ProcessResourcePolicyBuilder.cs
+++ b/src/CliInvoke.Core/Builders/ProcessResourcePolicyBuilder.cs
@@ -11,6 +11,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
+using AlastairLundy.CliInvoke.Core.Abstractions.Builders;
 using AlastairLundy.CliInvoke.Core.Builders.Abstractions;
 using AlastairLundy.CliInvoke.Core.Primitives.Policies;
 #if NET5_0_OR_GREATER

--- a/src/CliInvoke.Core/CliInvoke.Core.csproj
+++ b/src/CliInvoke.Core/CliInvoke.Core.csproj
@@ -30,7 +30,8 @@
         <PackageReference Include="AlastairLundy.DotExtensions" Version="7.1.1" />
         <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
         
-        <PackageReference Include="Polyfill" Version="7.33.0" Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" />
+        <PackageReference Include="Polyfill" Version="7.33.0" Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'"
+        PrivateAssets="All"/>
 
     </ItemGroup>
 

--- a/src/CliInvoke.Specializations/CliInvoke.Specializations.csproj
+++ b/src/CliInvoke.Specializations/CliInvoke.Specializations.csproj
@@ -26,7 +26,7 @@
     </PropertyGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Polyfill" Version="7.33.0" />
+        <PackageReference Include="Polyfill" Version="7.33.0" PrivateAssets="All"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/CliInvoke/CliInvoke.csproj
+++ b/src/CliInvoke/CliInvoke.csproj
@@ -45,7 +45,8 @@
     </ItemGroup>
     
     <ItemGroup >
-        <PackageReference Include="PolyFill" Version="7.33.0" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'"/>
+        <PackageReference Include="PolyFill" Version="7.33.0" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'"
+        PrivateAssets="All"/>
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
CliInvoke's usage of Polyfill has always been internal as an implementation detail to help backport missing functionality to older TFMs like .NET Standard 2.0 and .NET Standard 2.1 . As such there is no need to expose it as an explicit dependency.