### PR TITLE
``FilePathResolver.Shared`` resolver removal

### DIFF
--- a/benchmarks/CliInvoke.Benchmarks/Data/BufferedTestHelper.cs
+++ b/benchmarks/CliInvoke.Benchmarks/Data/BufferedTestHelper.cs
@@ -17,7 +17,7 @@ public class BufferedTestHelper
 
         try
         {
-            FileInfo fileResult = FilePathResolver.Shared.ResolveFilePath(mockDataToolExe);
+            FileInfo fileResult = new FilePathResolver().ResolveFilePath(mockDataToolExe);
 
             return fileResult.FullName;
         }

--- a/benchmarks/CliInvoke.Benchmarks/Data/DotnetCommandHelper.cs
+++ b/benchmarks/CliInvoke.Benchmarks/Data/DotnetCommandHelper.cs
@@ -4,7 +4,7 @@ public class DotnetCommandHelper
 {
     public DotnetCommandHelper()
     {
-        FileInfo fileResult = FilePathResolver.Shared.ResolveFilePath(
+        FileInfo fileResult = new FilePathResolver().ResolveFilePath(
             OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
         
         DotnetExecutableTargetFilePath = fileResult.FullName;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,7 +122,7 @@ finally
 `ExternalProcess.StartAsync` performs three things in order:
 
 1. Resolves the target file path through the injected
-   `IFilePathResolver` (defaults to `FilePathResolver.Shared`).
+   `IFilePathResolver` (defaulting to a fresh `FilePathResolver` instance).
 2. Constructs a new `ProcessWrapper` and calls `Start()` on it.
 3. If a `StandardInput` stream was supplied, copies it into the
    process's stdin asynchronously.

--- a/src/CliInvoke/Factories/ExternalProcessFactory.cs
+++ b/src/CliInvoke/Factories/ExternalProcessFactory.cs
@@ -21,10 +21,15 @@ public class ExternalProcessFactory : IExternalProcessFactory
     private readonly IFilePathResolver _filePathResolver;
 
     /// <summary>
+    ///     Initializes a new instance of the <see cref="ExternalProcessFactory"/> class
+    ///     and allocates a default <see cref="FilePathResolver"/> internally. This
+    ///     constructor performs an implicit <see cref="FilePathResolver"/> allocation;
+    ///     callers that need a custom resolver should use the
+    ///     <see cref="ExternalProcessFactory(IFilePathResolver)"/> overload instead.
     /// </summary>
     public ExternalProcessFactory()
     {
-        _filePathResolver = FilePathResolver.Shared;
+        _filePathResolver = new FilePathResolver();
     }
 
     public ExternalProcessFactory(IFilePathResolver filePathResolver)

--- a/src/CliInvoke/FilePathResolver.cs
+++ b/src/CliInvoke/FilePathResolver.cs
@@ -20,11 +20,6 @@ namespace CliInvoke;
 public class FilePathResolver : IFilePathResolver
 {
     /// <summary>
-    /// A shared static instance of the <see cref="FilePathResolver"/> class.
-    /// </summary>
-    public static FilePathResolver Shared { get; } = new();
-    
-    /// <summary>
     /// Resolves a file path by checking if the file path exists or if it's a directory.
     /// </summary>
     /// <param name="filePathToResolve">The file path to resolve.</param>

--- a/src/CliInvoke/Processes/ExternalProcess.cs
+++ b/src/CliInvoke/Processes/ExternalProcess.cs
@@ -39,13 +39,20 @@ public class ExternalProcess : ISuspendableExternalProcess, IExternalProcess
     }
 
     /// <summary>
+    ///     Initializes a new instance of the <see cref="ExternalProcess"/> class and
+    ///     allocates a default <see cref="FilePathResolver"/> internally to resolve
+    ///     the target executable path. This constructor performs an implicit
+    ///     <see cref="FilePathResolver"/> allocation; callers that need a custom
+    ///     resolver should use the
+    ///     <see cref="ExternalProcess(IFilePathResolver, ProcessConfiguration, ProcessExitConfiguration?)"/>
+    ///     overload instead.
     /// </summary>
     /// <param name="configuration"></param>
     /// <param name="exitConfiguration"></param>
     public ExternalProcess(ProcessConfiguration configuration,
         ProcessExitConfiguration? exitConfiguration = null)
     {
-        _filePathResolver = FilePathResolver.Shared;
+        _filePathResolver = new FilePathResolver();
         _processWrapper = new ProcessWrapper(configuration, configuration.ResourcePolicy);
         Configuration = configuration;
         ExitConfiguration = exitConfiguration ?? ProcessExitConfiguration.CreateGraceful();


### PR DESCRIPTION
This PR is in a mid-migration state — ``FilePathResolver.Shared`` is removed, the concrete`` FilePathResolver`` is the only ``IFilePathResolver`` implementer, methods are still protected (concrete) on the concrete, no base class yet.