### PR TITLE
``ProcessConfiguration`` refactor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
     <!-- Allow running MTP-based tests with dotnet test (VSTest mode) for SDKs that require it -->
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsAsErrors>CS1574;CS1580;CS1581;CS1584;CS1658;CS1734;CS1762</WarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
+++ b/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
@@ -28,32 +28,8 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
     /// <exception cref="ArgumentNullException"></exception>
     public ProcessConfiguration(string targetFilePath, string arguments = "", 
         bool outputRedirection = true)
+        : this(targetFilePath, arguments, redirectStandardInput: false, outputRedirection: outputRedirection)
     {
-        ArgumentException.ThrowIfNullOrEmpty(targetFilePath);
-        ArgumentNullException.ThrowIfNull(arguments);
-        
-        TargetFilePath = targetFilePath;
-        Arguments = arguments;
-        RedirectStandardInput = false;
-        OutputRedirection = outputRedirection;
-        
-        RequiresAdministrator = false;
-        WorkingDirectoryPath = Directory.GetCurrentDirectory();
-        EnvironmentVariables = new Dictionary<string, string>();
-        Credential = UserCredential.Null;
-
-        ResourcePolicy = ProcessResourcePolicy.Default;
-
-        StandardInput = StreamWriter.Null;
-
-        RedirectStandardInput = StandardInput != StreamWriter.Null;
-        
-        UseShellExecution = false;
-        WindowCreation = false;
-
-        StandardInputEncoding = Encoding.Default;
-        StandardOutputEncoding = Encoding.Default;
-        StandardErrorEncoding = Encoding.Default;
     }
 
     protected ProcessConfiguration(
@@ -74,6 +50,7 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
         bool useShellExecution = false)
     {
         ArgumentException.ThrowIfNullOrEmpty(targetFilePath);
+        ArgumentNullException.ThrowIfNull(arguments);
 
         TargetFilePath = targetFilePath;
         

--- a/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
+++ b/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
@@ -95,7 +95,7 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
     /// <summary>
     ///     The arguments to be provided to the executable to be run.
     /// </summary>
-    public string Arguments { get; protected set; }
+    public string Arguments { get; }
 
     /// <summary>
     ///     Whether to enable window creation or not when the Command's Process is run.
@@ -142,7 +142,7 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
     /// <summary>
     /// 
     /// </summary>
-    public bool OutputRedirection { get; protected set; }
+    public bool OutputRedirection { get; }
 
     /// <summary>
     ///     The Process Resource Policy to be used for executing the Command.

--- a/src/CliInvoke/Builders/ProcessConfigurationBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessConfigurationBuilder.cs
@@ -405,7 +405,7 @@ public class ProcessConfigurationBuilder : IProcessConfigurationBuilder, IDispos
         ProcessResourcePolicy resourcePolicy = _processResourcePolicyBuilder.Build();
         UserCredential credential = _userCredentialBuilder.Build();
 
-        ProcessConfigurationWrapper configuration = new(_targetFilePath, arguments,
+        BuilderProcessConfiguration configuration = new(_targetFilePath, arguments,
             _redirectStandardInput, _outputRedirection,
             _workingDirectoryPath, _requiresAdministratorPrivileges, environmentVariables,
             credential, _standardInput, _standardInputEncoding, _standardOutputEncoding, _standardErrorEncoding, resourcePolicy, _enableWindowCreation,
@@ -423,9 +423,9 @@ public class ProcessConfigurationBuilder : IProcessConfigurationBuilder, IDispos
     }
 }
 
-internal class ProcessConfigurationWrapper : ProcessConfiguration
+internal class BuilderProcessConfiguration : ProcessConfiguration
 {
-    internal ProcessConfigurationWrapper(string targetFilePath, string arguments,
+    internal BuilderProcessConfiguration(string targetFilePath, string arguments,
         bool redirectStandardInput,
         bool outputRedirection = false,
         string? workingDirectoryPath = null, bool requiresAdministrator = false,

--- a/src/CliInvoke/Builders/ProcessConfigurationBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessConfigurationBuilder.cs
@@ -423,6 +423,21 @@ public class ProcessConfigurationBuilder : IProcessConfigurationBuilder, IDispos
     }
 }
 
+/// <summary>
+/// An internal subclass of <see cref="ProcessConfiguration"/> used by <see cref="ProcessConfigurationBuilder"/> to invoke the protected multi-parameter constructor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The builder lives in the <c>CliInvoke</c> assembly, while <see cref="ProcessConfiguration"/> and its multi-parameter protected constructor reside in the <c>CliInvoke.Core</c> assembly.
+/// Cross-assembly access to the protected constructor requires this internal wrapper class as the legitimate access path.
+/// </para>
+/// <para>
+/// Do not delete this class without first choosing a long-term replacement.
+/// </para>
+/// <para>
+/// A long-term solution to eliminate this wrapper is being developed. See <see cref="ProcessConfigurationBuilder"/> for the current consumer.
+/// </para>
+/// </remarks>
 internal class BuilderProcessConfiguration : ProcessConfiguration
 {
     internal BuilderProcessConfiguration(string targetFilePath, string arguments,

--- a/src/CliInvoke/Builders/ProcessConfigurationBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessConfigurationBuilder.cs
@@ -78,7 +78,7 @@ public class ProcessConfigurationBuilder : IProcessConfigurationBuilder, IDispos
     /// <param name="arguments">The process arguments to be added or updated.</param>
     /// <param name="escapeArguments">Whether the arguments should be escaped.</param>
     /// <returns>A reference to this builder with the added arguments, allowing method chaining.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref cref="arguments" /> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="arguments" /> is null.</exception>
     public IProcessConfigurationBuilder SetArguments(
         IEnumerable<string> arguments,
         bool escapeArguments = true)

--- a/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
@@ -68,7 +68,7 @@ public class ProcessResourcePolicyBuilder : IProcessResourcePolicyBuilder
     /// <exception cref="ArgumentOutOfRangeException">
     ///     Thrown if <see cref="internalMinWorkingSet" /> is less than 0.
     /// </exception>
-    /// <exception cref="ArgumentException">Thrown if the <see cref="minWorkingSet"/> is greater than or equal to the maximum working set.</exception>
+    /// <exception cref="ArgumentException">Thrown if the <paramref name="minWorkingSet"/> is greater than or equal to the maximum working set.</exception>
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("macos")]
     [SupportedOSPlatform("maccatalyst")]

--- a/tests/CliInvoke.Tests/Primitives/ProcessConfigurationTests.cs
+++ b/tests/CliInvoke.Tests/Primitives/ProcessConfigurationTests.cs
@@ -1,0 +1,36 @@
+namespace CliInvoke.Tests.Primitives;
+
+public class ProcessConfigurationTests
+{
+    [Test]
+    public async Task Constructor_WithNullArguments_ThrowsArgumentNullException()
+    {
+        // Arrange & Act & Assert
+        await Assert.That(() => new ProcessConfiguration("foo.exe", null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_WithValidArguments_DoesNotThrow()
+    {
+        // Arrange & Act & Assert
+        await Assert.That(() => new ProcessConfiguration("foo.exe", "arg1"))
+            .ThrowsNothing();
+    }
+
+    [Test]
+    public async Task Constructor_WithDefaultArguments_DoesNotThrow()
+    {
+        // Arrange & Act & Assert
+        await Assert.That(() => new ProcessConfiguration("foo.exe"))
+            .ThrowsNothing();
+    }
+
+    [Test]
+    public async Task Constructor_WithNullTargetFilePath_ThrowsArgumentException()
+    {
+        // Arrange & Act & Assert
+        await Assert.That(() => new ProcessConfiguration(null!, "arg1"))
+            .Throws<ArgumentException>();
+    }
+}

--- a/tickets/001-move-arguments-null-check.md
+++ b/tickets/001-move-arguments-null-check.md
@@ -1,0 +1,98 @@
+---
+title: Move arguments null check to 15-param ctor and delegate 3-param ctor
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-CliInvoke-process-configuration-shape.md
+---
+
+## Goal
+
+Collapse the two `ProcessConfiguration` ctors into a single canonical shape so that the 15-param ctor is the single source of truth for argument validation, while the public 3-param ctor becomes a thin delegator. This honors the frozen-type contract from the Decision Ledger and eliminates the line 49 dead-code bug in the 3-param ctor body.
+
+## What to build
+
+In `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs`, refactor the ctor pair so that:
+
+1. The 15-param ctor (lines 59–101) gains an `ArgumentNullException.ThrowIfNull(arguments);` check placed immediately after the existing `ArgumentException.ThrowIfNullOrEmpty(targetFilePath);` check on line 76.
+2. The 3-param ctor (lines 29–57) is reduced to a single `: this(...)` delegation line; its body becomes empty.
+3. The line 49 dead-code assignment `RedirectStandardInput = StandardInput != StreamWriter.Null;` is removed (it is always `false` because `StandardInput` is set to `StreamWriter.Null` on line 47 and is moot once the ctor body delegates).
+
+The public 3-param ctor's signature stays at three params (`targetFilePath`, `arguments = ""`, `outputRedirection = true`) with the same defaults. The delegation passes `redirectStandardInput: false` and the caller's `outputRedirection` through to the 15-param ctor.
+
+The exception type and `paramName` for the `arguments` null case are preserved — callers that pass `null` to the 3-param ctor still get `ArgumentNullException` with `paramName = "arguments"` at construction.
+
+## Recommended Workflow
+
+### Step 1 — Add the null check to the 15-param ctor
+
+Where: `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs`
+
+- Open the 15-param ctor (lines 59–101).
+- Insert `ArgumentNullException.ThrowIfNull(arguments);` directly after line 76's `ArgumentException.ThrowIfNullOrEmpty(targetFilePath);` so the `targetFilePath` check stays first (it is the primary key per `DECISIONS-CliInvoke-process-configuration-shape.md#T001`).
+
+Verify: Reading the file, the 15-param ctor now has two consecutive argument-validation lines on `targetFilePath` and `arguments` before any field assignment.
+
+### Step 2 — Replace the 3-param ctor body with a delegation expression
+
+Where: `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs`
+
+- Replace lines 32–57 (the 3-param ctor body) with a single `: this(targetFilePath, arguments, redirectStandardInput: false, outputRedirection: outputRedirection)` constructor initializer per `DECISIONS-CliInvoke-process-configuration-shape.md#D011`.
+- Remove the now-redundant `ArgumentNullException.ThrowIfNull(arguments);` from the 3-param ctor (the check is reached via delegation per `DECISIONS-CliInvoke-process-configuration-shape.md#T001`).
+- Remove the line 49 dead-code assignment `RedirectStandardInput = StandardInput != StreamWriter.Null;` — it is always `false` and is moot once delegation takes over.
+
+Verify: The 3-param ctor body is empty; the 15-param ctor body is the only place where field assignments and validation live.
+
+### Step 3 — Add a test for `arguments` null behavior
+
+Where: `tests/CliInvoke.Tests/`
+
+- Add a test asserting `new ProcessConfiguration("foo.exe", null)` throws `ArgumentNullException` with `paramName = "arguments"`.
+- Add a sibling test confirming `new ProcessConfiguration("foo.exe", "arg1")` does not throw.
+- Add a sibling test confirming `new ProcessConfiguration("foo.exe")` (default `arguments = ""`) does not throw.
+- Add a sibling test confirming `new ProcessConfiguration(null, "arg1")` throws `ArgumentException` from `ThrowIfNullOrEmpty` on `targetFilePath`.
+
+Verify: `dotnet test` from `tests/CliInvoke.Tests/` (per the AGENTS.md working-directory convention) shows the new test passing and no regressions in existing tests.
+
+### Step 4 — Run the full test suite
+
+Where: N/A
+
+- Run `dotnet test` from `tests/CliInvoke.Tests/` to confirm no regressions across the three target frameworks (net8.0, net9.0, net10.0).
+
+Verify: All existing tests pass; the new test from Step 3 passes.
+
+## Context pointers
+
+**Files**
+- `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs` — the file being modified; the 3-param ctor at lines 29–57 and the 15-param ctor at lines 59–101 are the targets. The `Arguments` and `OutputRedirection` setters are addressed by a separate ticket (`002-remove-dead-setters`) and are not touched here.
+- `tests/CliInvoke.Tests/Builders/ProcessConfigurationBuilderTests.cs` — adjacent tests, useful as a reference for the test style; the new test goes in this project (path determined by the test framework's existing convention for `ProcessConfiguration` constructor tests).
+
+**ADRs** — None directly relevant. The frozen-type contract is recorded in the Decision Ledger, not an ADR.
+
+**Domain terms**
+- Frozen type — a type whose properties are set once at construction and never mutated afterwards, except for properties explicitly designated as resolution slots. In this codebase, `TargetFilePath` is the only resolution slot per `DECISIONS-CliInvoke-process-configuration-shape.md#D001` / `#D004`.
+- Canonical ctor — the single ctor that owns field assignment and validation; other ctors delegate to it.
+
+**Ledger records**
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D001` — frozen-at-construction contract that this ticket implements by collapsing validation into one place.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D004` — re-opened form of D001; supersedes D001 and confirms the wrapper stays (relevant because the wrapper at `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs:426` continues to call the 15-param ctor directly).
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D005` — 15-param ctor stays `protected`; the public 3-param ctor remains the only public ctor.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D011` — the 3-param ctor's delegation shape: `: this(targetFilePath, arguments, redirectStandardInput: false, outputRedirection: outputRedirection)` with an empty body.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#T001` — placement rule for the moved null check: immediately after the `targetFilePath` check on line 76.
+
+## Acceptance criteria
+
+- [ ] The 15-param ctor at `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs:59–101` contains `ArgumentNullException.ThrowIfNull(arguments);` placed directly after the existing `ArgumentException.ThrowIfNullOrEmpty(targetFilePath);` on line 76, per `DECISIONS-CliInvoke-process-configuration-shape.md#T001`.
+- [ ] The 3-param ctor at lines 29–57 has an empty body and delegates to the 15-param ctor via `: this(targetFilePath, arguments, redirectStandardInput: false, outputRedirection: outputRedirection)`, per `DECISIONS-CliInvoke-process-configuration-shape.md#D011`.
+- [ ] The line 49 dead-code assignment `RedirectStandardInput = StandardInput != StreamWriter.Null;` is removed (per `DECISIONS-CliInvoke-process-configuration-shape.md#D011`).
+- [ ] The 3-param ctor's null-check is removed from its body (the check is reached via delegation per `DECISIONS-CliInvoke-process-configuration-shape.md#T001`).
+- [ ] `new ProcessConfiguration("foo.exe", null)` throws `ArgumentNullException` with `paramName = "arguments"` (preserved public API behavior per `DECISIONS-CliInvoke-process-configuration-shape.md#T001`).
+- [ ] `new ProcessConfiguration("foo.exe")` (default `arguments = ""`) does not throw.
+- [ ] `new ProcessConfiguration("foo.exe", "arg1")` does not throw.
+- [ ] `new ProcessConfiguration(null, "arg1")` throws `ArgumentException` from `ThrowIfNullOrEmpty` on `targetFilePath`.
+- [ ] The 15-param ctor remains `protected` and is the only ctor that performs field assignment, per `DECISIONS-CliInvoke-process-configuration-shape.md#D005`.
+- [ ] `dotnet test` from `tests/CliInvoke.Tests/` passes with no regressions on net8.0, net9.0, and net10.0.
+
+## Dependencies
+
+**Blocked by** — None; this is a foundation ticket and can start immediately.

--- a/tickets/002-remove-dead-setters.md
+++ b/tickets/002-remove-dead-setters.md
@@ -1,0 +1,77 @@
+---
+title: Remove dead setters on Arguments and OutputRedirection
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-CliInvoke-process-configuration-shape.md
+---
+
+## Goal
+
+Honor the frozen-type contract from the Decision Ledger by removing the protected setters on `Arguments` and `OutputRedirection`, leaving `TargetFilePath` as the only mutable property on `ProcessConfiguration`. This is a dead-surface cleanup with no behavior change.
+
+## What to build
+
+In `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs`:
+
+1. Change line 121 from `public string Arguments { get; protected set; }` to `public string Arguments { get; }`.
+2. Change line 168 from `public bool OutputRedirection { get; protected set; }` to `public bool OutputRedirection { get; }`.
+
+The ctors continue to set the backing fields via direct field assignment in their bodies, which is permitted for `{ get; }` auto-properties. No production, test, or benchmark code calls these setters (verified before the change per `DECISIONS-CliInvoke-process-configuration-shape.md#D012`).
+
+## Recommended Workflow
+
+### Step 1 — Verify no callers use the setters
+
+Where: N/A (repo-wide grep)
+
+- Run a grep for `.Arguments =` and `.OutputRedirection =` across `src/`, `tests/`, and `benchmarks/`.
+- Confirm zero matches in production, test, or benchmark code before removing the setters, per `DECISIONS-CliInvoke-process-configuration-shape.md#D012`.
+
+Verify: Grep returns no matches; the setters are confirmed dead surface area.
+
+### Step 2 — Remove the protected setters
+
+Where: `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs`
+
+- Change line 121 from `public string Arguments { get; protected set; }` to `public string Arguments { get; }`.
+- Change line 168 from `public bool OutputRedirection { get; protected set; }` to `public bool OutputRedirection { get; }`.
+
+Verify: The two properties now declare only `{ get; }`; reading the file confirms no other lines reference `protected set` for these properties.
+
+### Step 3 — Confirm the ctors still compile and tests pass
+
+Where: N/A
+
+- Run `dotnet test` from `tests/CliInvoke.Tests/` per the AGENTS.md working-directory convention.
+- The ctors set the implicit backing fields directly, which remains legal for `{ get; }` auto-properties.
+
+Verify: The build succeeds and no existing tests regress on net8.0, net9.0, and net10.0.
+
+## Context pointers
+
+**Files**
+- `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs` — the file being modified; lines 121 and 168 are the targets.
+
+**ADRs** — None directly relevant.
+
+**Domain terms**
+- Frozen type — a type whose properties are set once at construction and never mutated afterwards, except for properties explicitly designated as resolution slots. `TargetFilePath` is the only resolution slot per `DECISIONS-CliInvoke-process-configuration-shape.md#D001` / `#D004`.
+
+**Ledger records**
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D001` — frozen-at-construction contract; this ticket enforces it by removing the last two setters that are not on the resolution slot.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D004` — re-opened form of D001; confirms the contract is in force and the wrapper (separately renamed) continues to call the 15-param ctor directly.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D012` — explicit decision to remove the `Arguments` and `OutputRedirection` protected setters; the only in-scope change is the setter visibility, not the property type or any constructor.
+
+## Acceptance criteria
+
+- [ ] A repo-wide grep for `.Arguments =` and `.OutputRedirection =` returns zero matches in `src/`, `tests/`, and `benchmarks/` before the change, per `DECISIONS-CliInvoke-process-configuration-shape.md#D012`.
+- [ ] Line 121 reads `public string Arguments { get; }` after the change.
+- [ ] Line 168 reads `public bool OutputRedirection { get; }` after the change.
+- [ ] The build succeeds with the new property declarations.
+- [ ] The 15-param ctor at lines 59–101 continues to assign the backing fields via direct field assignment, which is permitted for `{ get; }` auto-properties.
+- [ ] `TargetFilePath` remains the only property with a setter, per `DECISIONS-CliInvoke-process-configuration-shape.md#D001` / `#D004`.
+- [ ] `dotnet test` from `tests/CliInvoke.Tests/` passes with no regressions on net8.0, net9.0, and net10.0.
+
+## Dependencies
+
+**Blocked by** — None; this ticket is independent of the ctor-delegation work (`001-move-arguments-null-check`) and the rename work (`003-rename-wrapper-to-builder-process-configuration`). It can run in parallel with either.

--- a/tickets/003-rename-wrapper-to-builder-process-configuration.md
+++ b/tickets/003-rename-wrapper-to-builder-process-configuration.md
@@ -1,0 +1,85 @@
+---
+title: Rename ProcessConfigurationWrapper to BuilderProcessConfiguration
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-CliInvoke-process-configuration-shape.md
+---
+
+## Goal
+
+Rename the internal `ProcessConfigurationWrapper` subclass to `BuilderProcessConfiguration` for a self-documenting type name that reflects its only consumer (`ProcessConfigurationBuilder`). The class stays `internal`, the file path is unchanged, and the `outputRedirection = false` ctor default is preserved as a deliberate builder-centric divergence from the 15-param ctor's `true` default.
+
+## What to build
+
+In `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs`:
+
+1. Line 426: rename `internal class ProcessConfigurationWrapper : ProcessConfiguration` to `internal class BuilderProcessConfiguration : ProcessConfiguration`.
+2. Line 428: rename the ctor's name from `ProcessConfigurationWrapper` to `BuilderProcessConfiguration`. The `outputRedirection = false` default on line 430 is preserved (it is a deliberate builder-centric choice per `DECISIONS-CliInvoke-process-configuration-shape.md#T002`, not a bug to fix).
+3. Line 408: update the call site to `BuilderProcessConfiguration configuration = new(_targetFilePath, arguments, ...);` so it matches the renamed type.
+4. The `TargetFilePath` setter visibility is untouched — it remains `public` per `DECISIONS-CliInvoke-process-configuration-shape.md#D013` (the rename does not affect the resolution-slot contract).
+
+The file remains `ProcessConfigurationBuilder.cs`; only the type name, ctor name, and call site change.
+
+## Recommended Workflow
+
+### Step 1 — Verify no external references to the old name
+
+Where: N/A (repo-wide grep)
+
+- Run a grep for `ProcessConfigurationWrapper` across `src/`, `tests/`, and `benchmarks/`.
+- Confirm the only matches are at `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs:408` (call site) and lines 426, 428 (declaration and ctor).
+
+Verify: Grep returns three matches, all inside `ProcessConfigurationBuilder.cs`.
+
+### Step 2 — Rename the class declaration, ctor, and call site
+
+Where: `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs`
+
+- Rename line 426's `ProcessConfigurationWrapper` to `BuilderProcessConfiguration`.
+- Rename line 428's ctor name from `ProcessConfigurationWrapper` to `BuilderProcessConfiguration`.
+- Update line 408's call site to `BuilderProcessConfiguration configuration = new(_targetFilePath, arguments, _redirectStandardInput, _outputRedirection, _workingDirectoryPath, _requiresAdministratorPrivileges, environmentVariables, credential, _standardInput, _standardInputEncoding, _standardOutputEncoding, _standardErrorEncoding, resourcePolicy, _enableWindowCreation, _useShellExecution);`.
+- Leave the `outputRedirection = false` default on line 430 untouched — the divergence from the 15-param ctor's `true` default is intentional per `DECISIONS-CliInvoke-process-configuration-shape.md#T002`.
+
+Verify: A repo-wide grep for `ProcessConfigurationWrapper` returns zero matches.
+
+### Step 3 — Build and run tests
+
+Where: N/A
+
+- Run `dotnet test` from `tests/CliInvoke.Tests/` per the AGENTS.md working-directory convention.
+- Confirm the build succeeds and no existing tests regress.
+
+Verify: All existing tests pass on net8.0, net9.0, and net10.0.
+
+## Context pointers
+
+**Files**
+- `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs` — the file being modified; the class declaration is on line 426, the ctor on line 428, the call site on line 408, and the CA1416 pragma on lines 18 and 445 (unaffected by this change).
+- `tests/CliInvoke.Tests/Builders/ProcessConfigurationBuilderTests.cs` — adjacent tests; no direct reference to `ProcessConfigurationWrapper` is expected.
+
+**ADRs** — None directly relevant.
+
+**Domain terms**
+- Wrapper — in this codebase, an internal subclass of `ProcessConfiguration` whose only purpose is to call the `protected` 15-param ctor from a different assembly (`CliInvoke` vs `CliInvoke.Core`). The wrapper is the legitimate cross-assembly access path; a future direction may eliminate it (`DECISIONS-CliInvoke-process-configuration-shape.md#D006`, deferred).
+
+**Ledger records**
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D004` — re-opened form of D001; confirms the wrapper stays in renamed form and is the only consumer-facing access path from `CliInvoke` to the protected 15-param ctor.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D005` — 15-param ctor stays `protected`; the rename does not introduce `InternalsVisibleTo` and the access path remains the wrapper.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D007` — the rename itself: `ProcessConfigurationWrapper` becomes `BuilderProcessConfiguration`, the class stays `internal`, the file path is unchanged, and only the declaration (line 426), ctor name (line 428), and call site (line 408) are touched.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D013` — `TargetFilePath` setter visibility remains `public`; the rename does not affect the resolution-slot contract.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#T002` — the wrapper's `outputRedirection = false` default is deliberate and must not be "fixed" to match the 15-param ctor's `true` default. The wrapper's other 11 defaults match the 15-param ctor's defaults; `outputRedirection` is the only intentional divergence.
+
+## Acceptance criteria
+
+- [ ] A repo-wide grep for `ProcessConfigurationWrapper` returns zero matches after the change.
+- [ ] Line 426 reads `internal class BuilderProcessConfiguration : ProcessConfiguration`.
+- [ ] Line 428's ctor is named `BuilderProcessConfiguration` and its `outputRedirection = false` default on line 430 is preserved, per `DECISIONS-CliInvoke-process-configuration-shape.md#T002`.
+- [ ] Line 408's call site uses `BuilderProcessConfiguration` as the type of the local variable.
+- [ ] The class remains `internal` and continues to subclass `ProcessConfiguration`, per `DECISIONS-CliInvoke-process-configuration-shape.md#D005` and `#D007`.
+- [ ] The file path is unchanged — the class still lives in `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs`.
+- [ ] `TargetFilePath` setter visibility remains `public`, per `DECISIONS-CliInvoke-process-configuration-shape.md#D013`.
+- [ ] `dotnet test` from `tests/CliInvoke.Tests/` passes with no regressions on net8.0, net9.0, and net10.0.
+
+## Dependencies
+
+**Blocked by** — None; this ticket is independent of the ctor-delegation work (`001-move-arguments-null-check`) and the setter-removal work (`002-remove-dead-setters`). It can run in parallel with either. The follow-on remarks-block work (`004-add-remarks-block-to-wrapper`) is blocked by this rename.

--- a/tickets/004-add-remarks-block-to-wrapper.md
+++ b/tickets/004-add-remarks-block-to-wrapper.md
@@ -1,0 +1,89 @@
+---
+title: Add remarks block to BuilderProcessConfiguration
+classification: Independent
+blocked_by: [003-rename-wrapper-to-builder-process-configuration]
+parent: docs/decisions/DECISIONS-CliInvoke-process-configuration-shape.md
+---
+
+## Goal
+
+Add an agent-facing XML doc `<remarks>` block to the renamed `BuilderProcessConfiguration` class so that future maintainers and AI agents understand (a) why the wrapper exists, (b) why it must not be deleted, and (c) that a long-term solution to eliminate the wrapper is being developed. The block uses three `<para>` elements, a single `<see cref="ProcessConfigurationBuilder" />` cross-reference, and no references to any decision-ledger record.
+
+## What to build
+
+In `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs`, add an XML doc to the renamed `BuilderProcessConfiguration` class (line 426) with the following structure:
+
+- A minimal `<summary>` — "An internal subclass of `ProcessConfiguration` used by `ProcessConfigurationBuilder` to invoke the protected multi-parameter constructor."
+- A `<remarks>` block containing three `<para>` elements:
+  1. The ctor-availability problem statement: the builder lives in a different assembly (`CliInvoke`) than `ProcessConfiguration` (`CliInvoke.Core`), the multi-parameter constructor is `protected`, and this wrapper is the legitimate cross-assembly access path.
+  2. The no-delete rule: "Do not delete this class without first choosing a long-term replacement."
+  3. A plain-language mention that a long-term solution to eliminate the wrapper is being developed, with a `<see cref="ProcessConfigurationBuilder" />` cross-reference to the only consumer.
+
+The block must not reference any `Dxxx` ID or any decision-ledger filename (per `DECISIONS-CliInvoke-process-configuration-shape.md#D009`). The plain-language long-term mention survives any future ledger rename.
+
+This ticket assumes that `005-escalate-cref-warnings-as-errors` may run in parallel; if it has not yet been applied, a temporary broken-cref test cannot be run, but a valid-cref build is sufficient to confirm the remarks block compiles.
+
+## Recommended Workflow
+
+### Step 1 — Add the XML doc to the renamed class
+
+Where: `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs`
+
+- Open the renamed `BuilderProcessConfiguration` class declaration (line 426, after `003-rename-wrapper-to-builder-process-configuration` has landed).
+- Insert the `<summary>` and `<remarks>` block immediately above the class declaration.
+- Ensure the three `<para>` elements are present, with the `<see cref="ProcessConfigurationBuilder" />` in the third `<para>` per `DECISIONS-CliInvoke-process-configuration-shape.md#D010`.
+- Ensure no `Dxxx` ID, ledger filename, or any decision-ledger content is referenced in the block per `DECISIONS-CliInvoke-process-configuration-shape.md#D009`.
+
+Verify: Reading the file, the class has a `<summary>` and a `<remarks>` block with three `<para>` elements, and the only structured cross-reference is `<see cref="ProcessConfigurationBuilder" />` in the third `<para>`.
+
+### Step 2 — Confirm the build succeeds
+
+Where: N/A
+
+- Run `dotnet test` from `tests/CliInvoke.Tests/` per the AGENTS.md working-directory convention.
+- If `005-escalate-cref-warnings-as-errors` has already landed, the build must succeed with all crefs valid.
+
+Verify: The build succeeds on net8.0, net9.0, and net10.0; no new warnings or errors related to the new XML doc appear.
+
+### Step 3 — (Optional) Verify cref-warning escalation
+
+Where: `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs`
+
+- If `005-escalate-cref-warnings-as-errors` has landed, introduce a temporary broken cref (e.g., `<see cref="NonExistentClass" />`), confirm the build fails, then revert.
+- If `005-escalate-cref-warnings-as-errors` has not yet landed, skip this step — the escalation itself is verified in that ticket.
+
+Verify: A broken cref fails the build (when escalation is in force); reverting restores the green build.
+
+## Context pointers
+
+**Files**
+- `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs` — the file being modified; the renamed `BuilderProcessConfiguration` class is at line 426. The CA1416 pragma on lines 18 and 445 is unaffected.
+
+**ADRs** — None directly relevant. The cross-references in the remarks block point to source code only.
+
+**Domain terms**
+- Wrapper — an internal subclass of `ProcessConfiguration` whose only purpose is to call the `protected` 15-param ctor from a different assembly. The wrapper is the legitimate cross-assembly access path; a future direction may eliminate it (`DECISIONS-CliInvoke-process-configuration-shape.md#D006`, deferred).
+- Resolution slot — see `001-move-arguments-null-check`'s context pointers; not directly relevant to this ticket beyond noting that the wrapper exists because the resolution slot's surrounding ctor is `protected`.
+
+**Ledger records**
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D008` — the remarks block is the only agent-facing comment on the class; the `<summary>` is minimal and the block uses `<remarks>` (not an extended `<summary>` and not an inline `// note:` block).
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D009` — the three required elements: ctor-availability problem statement, no-delete rule, and a plain-language long-term mention; no `Dxxx` ID or ledger filename is referenced.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D010` — the single `<see cref="ProcessConfigurationBuilder" />` cross-reference, placed in the third `<para>`. The base type is already obvious from the `: ProcessConfiguration` declaration, so no second cref is added.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#T004` — the three-`<para>` structure: one paragraph per D009 element, with the cref in the third.
+
+## Acceptance criteria
+
+- [ ] The renamed `BuilderProcessConfiguration` class at `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs:426` carries a `<summary>` and a `<remarks>` block, per `DECISIONS-CliInvoke-process-configuration-shape.md#D008`.
+- [ ] The `<remarks>` block contains exactly three `<para>` elements, per `DECISIONS-CliInvoke-process-configuration-shape.md#T004`:
+  1. The ctor-availability problem statement, per `DECISIONS-CliInvoke-process-configuration-shape.md#D009`.
+  2. The no-delete rule ("do not delete this class without first choosing a long-term replacement"), per `DECISIONS-CliInvoke-process-configuration-shape.md#D009`.
+  3. A plain-language long-term mention, per `DECISIONS-CliInvoke-process-configuration-shape.md#D009`.
+- [ ] The third `<para>` contains a `<see cref="ProcessConfigurationBuilder" />` cross-reference, per `DECISIONS-CliInvoke-process-configuration-shape.md#D010`.
+- [ ] The remarks block contains no `Dxxx` ID and no decision-ledger filename, per `DECISIONS-CliInvoke-process-configuration-shape.md#D009`.
+- [ ] The `<summary>` is minimal (does not duplicate the remarks content), per `DECISIONS-CliInvoke-process-configuration-shape.md#D008`.
+- [ ] The build succeeds on net8.0, net9.0, and net10.0; no new warnings or errors are introduced by the new XML doc.
+- [ ] If `005-escalate-cref-warnings-as-errors` has already landed, a temporary broken cref in the remarks block fails the build (verified by introducing and reverting), per `DECISIONS-CliInvoke-process-configuration-shape.md#T003`.
+
+## Dependencies
+
+**Blocked by** — `003-rename-wrapper-to-builder-process-configuration` (the class must be renamed first, because the remarks block documents the renamed `BuilderProcessConfiguration` and the file no longer references `ProcessConfigurationWrapper` after that ticket lands).

--- a/tickets/005-escalate-cref-warnings-as-errors.md
+++ b/tickets/005-escalate-cref-warnings-as-errors.md
@@ -1,0 +1,84 @@
+---
+title: Escalate targeted cref warnings as errors in Directory.Build.props
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-CliInvoke-process-configuration-shape.md
+---
+
+## Goal
+
+Make the build fail on broken `<see cref="..." />` cross-references in XML doc comments, without the broader disruption of global `<TreatWarningsAsErrors>`. This is the build-config counterpart to `004-add-remarks-block-to-wrapper` — the wrapper's cref to `ProcessConfigurationBuilder` (and any other cref in the project) gets build-failure protection.
+
+## What to build
+
+In `Directory.Build.props`, add a new `<WarningsAsErrors>` element to the existing `<PropertyGroup>` (lines 2–6) with the following content:
+
+```xml
+<WarningsAsErrors>CS1574;CS1580;CS1581;CS1584;CS1658;CS1734;CS1762</WarningsAsErrors>
+```
+
+The list applies project-wide. The wrapper's remarks block (added by `004-add-remarks-block-to-wrapper`) is the primary motivator, but the protection is not scoped to the wrapper.
+
+Existing `#pragma warning disable` blocks are unaffected: CS0618 at `ProcessConfiguration.cs:91–93`, CS8602 at `ProcessConfiguration.cs:217, 233`, and CA1416 at `ProcessConfigurationBuilder.cs:18, 445` continue to suppress those specific warnings.
+
+## Recommended Workflow
+
+### Step 1 — Add the WarningsAsErrors property
+
+Where: `Directory.Build.props`
+
+- Open the existing `<PropertyGroup>` (lines 2–6).
+- Add a new line: `<WarningsAsErrors>CS1574;CS1580;CS1581;CS1584;CS1658;CS1734;CS1762</WarningsAsErrors>`.
+- Leave the existing `<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>` and `<GenerateDocumentationFile>true</GenerateDocumentationFile>` lines untouched.
+
+Verify: Reading the file, the `<PropertyGroup>` now contains three child elements: the two existing ones and the new `<WarningsAsErrors>` line.
+
+### Step 2 — Confirm the build succeeds with all crefs valid
+
+Where: N/A
+
+- Run `dotnet test` from `tests/CliInvoke.Tests/` per the AGENTS.md working-directory convention.
+- If `004-add-remarks-block-to-wrapper` has landed, the wrapper's `<see cref="ProcessConfigurationBuilder" />` cref is valid and the build must succeed.
+- If `004-add-remarks-block-to-wrapper` has not yet landed, the build must still succeed because all existing crefs in the codebase are valid.
+
+Verify: The build succeeds on net8.0, net9.0, and net10.0 with no new errors.
+
+### Step 3 — Verify escalation with a temporary broken cref
+
+Where: any `.cs` file with an XML doc that already has a `<see cref="..." />` (e.g., `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs` once `004-add-remarks-block-to-wrapper` has landed)
+
+- Introduce a temporary broken cref (e.g., `<see cref="NonExistentClass" />` in the wrapper's remarks block, or in any existing cref site).
+- Run `dotnet test` and confirm the build fails with one of the listed warning codes (CS1574, CS1580, CS1581, CS1584, CS1658, CS1734, CS1762).
+- Revert the broken cref.
+
+Verify: A broken cref causes the build to fail with a cref-related warning promoted to an error; reverting restores the green build. The temporary broken cref is removed before the ticket is marked complete.
+
+## Context pointers
+
+**Files**
+- `Directory.Build.props` — the file being modified; the `<PropertyGroup>` is at lines 2–6.
+- `src/CliInvoke.Core/Primitives/ProcessConfiguration.cs` — adjacent file with `#pragma warning disable` blocks (CS0618 at lines 91–93, CS8602 at lines 217 and 233); these are unaffected by the new `<WarningsAsErrors>` line.
+- `src/CliInvoke/Builders/ProcessConfigurationBuilder.cs` — adjacent file with a CA1416 pragma on lines 18 and 445; unaffected. The wrapper's remarks block (added by `004-add-remarks-block-to-wrapper`) is the primary target of the new escalation.
+
+**ADRs** — None directly relevant.
+
+**Domain terms**
+- cref — an XML doc cross-reference. A broken cref (a target that the compiler cannot resolve) emits one of the CS1574, CS1580, CS1581, CS1584, CS1658, CS1734, or CS1762 warnings. With `<GenerateDocumentationFile>true</GenerateDocumentationFile>` already enabled in `Directory.Build.props:5`, the warning is emitted; this ticket escalates it to an error.
+
+**Ledger records**
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D008` — the remarks block format choice; escalation protects the remarks block from silently broken crefs.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D009` — the remarks block scope; escalation applies project-wide but is motivated by the remarks block.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#D010` — the `<see cref="ProcessConfigurationBuilder" />` cross-reference; escalation guarantees the cref points to a real type at build time.
+- `DECISIONS-CliInvoke-process-configuration-shape.md#T003` — the targeted list of warning codes: CS1574, CS1580, CS1581, CS1584, CS1658, CS1734, CS1762. The list must be reviewed during .NET upgrades to catch any new codes the compiler adds.
+
+## Acceptance criteria
+
+- [ ] `Directory.Build.props` contains a `<WarningsAsErrors>` element with the value `CS1574;CS1580;CS1581;CS1584;CS1658;CS1734;CS1762`, per `DECISIONS-CliInvoke-process-configuration-shape.md#T003`.
+- [ ] The existing `<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>` and `<GenerateDocumentationFile>true</GenerateDocumentationFile>` lines are preserved.
+- [ ] The existing `#pragma warning disable` blocks are unaffected: CS0618 at `ProcessConfiguration.cs:91–93`, CS8602 at `ProcessConfiguration.cs:217, 233`, and CA1416 at `ProcessConfigurationBuilder.cs:18, 445` continue to suppress those warnings.
+- [ ] The build succeeds on net8.0, net9.0, and net10.0 with all valid crefs.
+- [ ] A temporary broken cref (e.g., `<see cref="NonExistentClass" />`) causes the build to fail with one of the listed warning codes, per `DECISIONS-CliInvoke-process-configuration-shape.md#T003`. The temporary change is reverted before the ticket is marked complete.
+
+## Dependencies
+
+**Blocked by** — None; this ticket can be done at any time. The blueprint's recommended order is Step 1 → Step 2 → Step 3 → Step 4 → Step 5, but Step 5 (`005-escalate-cref-warnings-as-errors`) is independent and can be moved earlier if desired.


### PR DESCRIPTION
**Refactor `ProcessConfiguration` constructors and harden XML doc cref checks**

### Summary
Cleans up `ProcessConfiguration` construction, removes duplicated initialization, drops dead `protected set` accessors, and escalates XML `cref`/`paramref` warnings to errors. Companion tests cover the new constructor behavior.

### Changes
- **`ProcessConfiguration`**: 3-param ctor now delegates to the 15-param ctor; `ArgumentNullException` guard for `arguments` consolidated; dropped dead `protected set` on `Arguments` and `OutputRedirection`.
- **`ProcessConfigurationBuilder`**: Renamed `ProcessConfigurationWrapper` → `BuilderProcessConfiguration` with a `<remarks>` block explaining its cross-assembly role; fixed broken `<paramref>` in `SetArguments` doc.
- **`ProcessResourcePolicyBuilder`**: Fixed broken `<paramref cref="minWorkingSet"/>`.
- **`Directory.Build.props`**: Escalated `CS1574`, `CS1580`, `CS1581`, `CS1584`, `CS1658`, `CS1734`, `CS1762` to errors.
- **Tests**: New `ProcessConfigurationTests` covering null/valid/default `arguments` and null `targetFilePath`.
- **`tickets/`**: Five planning tickets (`001`–`005`) for each unit of work.

### Compatibility
Internal/refactor only; public API unchanged. Run `dotnet test` from `tests/CliInvoke.Tests/` before merge.

---
Code *Co-authored by GitHub Copilot using Claude 4.5 Haiku*