### PR TITLE
docs: add persona-driven landing page to Developer Portal

### DIFF
--- a/site/docs/readme.md
+++ b/site/docs/readme.md
@@ -1,6 +1,5 @@
 ---
 title: Documentation
-layout: simple
 ---
 
 # CliInvoke Documentation

--- a/site/docs/readme.md
+++ b/site/docs/readme.md
@@ -1,7 +1,134 @@
 ---
 title: Documentation
+layout: simple
 ---
 
-# Documentation
+# CliInvoke Documentation
 
-Welcome to the documentation section. Add more pages here and reference them in `docs/menu.yml`.
+The CliInvoke library offers three patterns for invoking external
+processes from .NET, each tuned to a different audience and trade-off
+space. This page is the central hub of the Developer Portal — it
+routes you to the right specialized documentation based on **who you
+are** and **what you're trying to do**.
+
+## I am a …
+
+Pick the description that fits you best. Each path is designed to
+land you on a working example or the right reference in 1–3 clicks.
+
+### Beginner — "I just need to run a command"
+
+You want to launch a process, capture its output, and move on. No
+DI container, no builders, no ceremony.
+
+**Start here** — copy, paste, run:
+
+```csharp
+using CliInvoke;
+using CliInvoke.Core;
+
+// Execute a command and wait for it to finish.
+ProcessResult result = await CliRun.RunAsync("dotnet", "--version");
+Console.WriteLine($"Exit Code: {result.ExitCode}");
+```
+
+That's a complete working program using the beginner-friendly
+[`CliRun`](guides/choosing-invocation-pattern.md#cirun--quickstart-scripting)
+façade — one click from this page to a runnable example.
+
+**When you're ready for more:**
+
+- [Choosing your Invocation Pattern](guides/choosing-invocation-pattern.md)
+  — when to stay on `CliRun` and when to graduate.
+- [Quickstart](getting-started-quickstart.md) — install, register,
+  and run.
+- [Getting Started](getting-started.md) — full installation and
+  setup walkthrough.
+
+### Professional Developer — "I'm building a testable app with DI"
+
+You work in a codebase that uses dependency injection, you need to
+unit-test code that calls out to processes, and you want clean
+separation between configuration and execution.
+
+**Start here:**
+
+1. [Choosing your Invocation Pattern](guides/choosing-invocation-pattern.md) —
+   follow the decision tree to `IProcessInvoker`.
+2. [Getting Started → Setting up CliInvoke](getting-started.md#setting-up-cliinvoke) —
+   register `IProcessInvoker` with your DI container.
+3. [Configuration](guides/configuration.md) — the `ProcessConfiguration`
+   model, the builder lifecycle, and the default-value reference
+   appendix.
+
+### Power User — "I need full lifecycle control"
+
+You need to interact with the process while it runs (pipe input
+after `Start`, monitor progress, send signals), or replace
+components for advanced scenarios.
+
+**Start here:**
+
+1. [Choosing your Invocation Pattern → `IExternalProcess`](guides/choosing-invocation-pattern.md)
+   — when and how to use the factory + lifecycle API.
+2. [Architecture](guides/architecture.md) — the internal data-flow
+   so you can reason about where a customisation belongs.
+3. [Configuration](guides/configuration.md) — every knob on
+   `ProcessConfiguration` and `ProcessExitConfiguration`.
+
+## I want to …
+
+If you know what you need to accomplish but not which page it's on,
+jump straight to the relevant guide.
+
+| I want to … | Go to |
+|---|---|
+| Debug a leak, hang, or wrong exit code | [Troubleshooting](guides/troubleshooting.md) |
+| Tune how a process starts or exits | [Configuration](guides/configuration.md) |
+| Understand the internal data-flow | [Architecture](guides/architecture.md) |
+| Pick between `CliRun`, `IProcessInvoker`, and `IExternalProcess` | [Choosing your Invocation Pattern](guides/choosing-invocation-pattern.md) |
+| Dispose the Resource-Owning Types correctly | [Resource Disposal](guides/resource-disposal.md) |
+| Install and set up the library | [Getting Started](getting-started.md) · [Quickstart](getting-started-quickstart.md) |
+| Migrate from v1 to v2 | [Migration Guides](migration-guides/) |
+| Look up a specific API | [API Reference](../api/) |
+
+## All documentation
+
+A flat index of every page in this Developer Portal.
+
+### Getting started
+
+- [Quickstart](getting-started-quickstart.md) — install and run
+  your first `CliRun` command in under five minutes.
+- [Getting Started](getting-started.md) — full installation, DI
+  setup, and worked examples.
+
+### Guides
+
+- [Choosing your Invocation Pattern](guides/choosing-invocation-pattern.md)
+  — decision tree and trade-offs for `CliRun`, `IProcessInvoker`,
+  and `IExternalProcess`.
+- [Architecture](guides/architecture.md) — the four-stage data-flow
+  from configuration to result.
+- [Configuration](guides/configuration.md) — `ProcessConfiguration`,
+  builders, defaults, and the reference appendix.
+- [Resource Disposal](guides/resource-disposal.md) — the five
+  Resource-Owning Types and the disposal patterns they require.
+- [Troubleshooting](guides/troubleshooting.md) — category-based
+  failure diagnosis with detection methods.
+
+### Other
+
+- [Building CliInvoke](building-cliinvoke.md) — build the library
+  from source.
+- [Migration Guides](migration-guides/) — v1 → v2 and other
+  migrations.
+- [API Reference](../api/) — auto-generated API reference.
+
+## Beyond the portal
+
+- [GitHub repository](https://github.com/alastairlundy/CliInvoke) —
+  source, issues, and discussions.
+- [NuGet packages](https://www.nuget.org/packages/CliInvoke) —
+  `CliInvoke`, `CliInvoke.Core`, `CliInvoke.Extensions`, and
+  `CliInvoke.Specializations`.


### PR DESCRIPTION
## What changed

Replaced the placeholder content of `site/docs/readme.md` with a persona-driven User-Journey map that serves as the central hub of the Developer Portal.

The new landing page has three primary sections:

- **I am a ...** — three persona cards (Beginner, Professional Developer, Power User), each with a numbered path that lands the visitor on a working example or the right reference in 1-3 clicks.
- **I want to ...** — intent-based navigation table linking to Troubleshooting, Configuration, Architecture, Choosing your Invocation Pattern, Resource Disposal, Getting Started, Migration Guides, and the API Reference.
- **All documentation** — flat index of every page in the Developer Portal, including the five guides created in #348-#352 (Resource Disposal, Architecture, Configuration, Troubleshooting, Choosing your Invocation Pattern).

The page also includes a "Beyond the portal" section linking to the GitHub repository and the NuGet packages.

A Beginner lands directly on a working `CliRun.RunAsync("dotnet", "--version")` example (inline in the Beginner section) with two 1-click fallbacks: the Quickstart and the `CliRun` section of the Pattern Guide. This is well within the 3-click acceptance criterion in #353.

## Why it was changed

Issue #353 asked for a User-Journey map that routes users based on their personas and intent to the appropriate specialized documentation. The existing `site/docs/readme.md` was a one-line placeholder ("Welcome to the documentation section...") that gave first-time visitors no entry point into the five new guides created in #348-#352.

Path note: the issue referenced `docs/index.md`, but the project convention (no `index.md` exists anywhere under `site/`) is `readme.md` per section. The dependent pages #348-#352 were placed at `site/docs/guides/`, so the developer-portal landing page lives at `site/docs/readme.md` — already the first entry in `site/docs/menu.yml`. No menu change was required.

## Testing

- [ ] `dotnet test` passes locally on the supported TFMs
- [x] New or updated tests are included for the change (N/A — documentation-only change)
- [x] Behavior-affecting changes are covered by tests (N/A — no behavior change)

Verification done in this session:

- `lunet build` succeeds and produces `docs/index.html` (14.7 KB).
- All 11 expected sections and links are present in the rendered HTML (Beginner, Professional Developer, Power User, I want to, All documentation, CliRun.RunAsync, choosing-invocation-pattern, troubleshooting, resource-disposal, configuration, architecture).
- Beginner click-budget verified: 0 clicks to a working `CliRun.RunAsync` example (inline), with two 1-click fallbacks.

The build emits one pre-existing error on `site/docs/guides/choosing-invocation-pattern.md` that is unrelated to this change (it predates this branch).

## Documentation

- [x] README, docs/, or XML doc comments updated (if applicable)
- [ ] VERSION_HISTORY.md updated (if user-visible)
- [ ] No docs change needed

## Contribution Policy compliance

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [x] My branch is up to date with `main` and the diff is focused
- [x] Commit messages are clear and describe the change
- [x] I have not introduced secrets, credentials, or copyrighted content
- [x] For changes that affect resource-owning types, I followed the disposal conventions in the README (N/A — no code change)

## Authorship

- [ ] This PR was written entirely by a human (no AI assistance)
- [x] This PR was Co-Authored by AI (the human author reviewed, edited, and takes responsibility for the final code; commits include the appropriate `Co-authored-by:` trailer(s))

- **AI agent used:** GitHub Copilot CLI
- **AI model used:** minimax-m3

Fixes: #353