### PR TITLE
Pin lunet-build action to commit SHA in docs-publish workflow

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - id: lunet
         name: Build and deploy Lunet site
-        uses: lunet-io/actions/lunet-build@v1
+        uses: lunet-io/actions/lunet-build@324085f316e425108daa2183106c6ace59d6ee2d # v1
         with:
           site_path: site


### PR DESCRIPTION
Fixes [code scanning alert #46](https://github.com/alastairlundy/CliInvoke/security/code-scanning/46) (Pinned-Dependencies).

Pins `lunet-io/actions/lunet-build` to its commit SHA (`324085f316e425108daa2183106c6ace59d6ee2d`) instead of the mutable `v1` tag. The tag comment is preserved for readability.

Co-authored by GitHub Copilot App (powered by Qwen3.7 Plus).