### PR TITLE
Rewrite docs landing and add architecture guide

### DIFF
--- a/site/config.scriban
+++ b/site/config.scriban
@@ -5,7 +5,7 @@ template_theme_default_mode = "system"
 
 # Project metadata - set these before calling site_project_init.
 site_project_name = "CliInvoke"
-site_project_description = "A website built with Lunet."
+site_project_description = "CliInvoke is a .NET library for running and interacting with external command-line processes, with three invocation patterns, configuration builders, and cross-platform support."
 site_project_baseurl = "https://alastairlundy.github.io/CliInvoke"
 site_project_basepath = "/CliInvoke"
 site_project_github_user = "alastairlundy"

--- a/site/docs/guides/architecture.md
+++ b/site/docs/guides/architecture.md
@@ -3,4 +3,492 @@ title: Architecture
 layout: simple
 ---
 
-Placeholder for Architecture conceptual guide. Migrate content from DocFX source and include diagrams and examples.
+# Architecture
+
+This guide explains how CliInvoke works internally. It walks through the
+data-flow that every invocation follows, shows how the three invocation
+patterns (`CliRun`, `IProcessInvoker`, `IExternalProcess`) enter and exit
+that data-flow, and describes the **Process Invocation Pipeline** — the
+layered pattern CliInvoke uses to keep cross-cutting concerns (path
+resolution, runner wrapping, result validation) out of the core execution
+path.
+
+If you only read one section, read
+[The data-flow](#the-data-flow-builder--model--invoker--result) and
+[The Process Invocation Pipeline](#the-process-invocation-pipeline).
+
+## Goals
+
+This page exists to answer four questions precisely:
+
+1. What does an invocation look like end-to-end, from the moment a caller
+   decides to run a command to the moment the caller receives a result?
+2. Which types are involved at each stage, and what are the boundaries
+   between them?
+3. How do the three invocation patterns map onto that data-flow?
+4. Where does custom logic (path resolution, result validation, runner
+   wrapping) plug in?
+
+## Terminology
+
+The following terms are used throughout this guide. They mirror the
+canonical definitions in
+[`CONTEXT.md`](https://github.com/alastairlundy/CliInvoke/blob/main/CONTEXT.md#core-concepts).
+
+A **Builder** is a fluent, mutable object used to assemble a configuration
+model. Each builder is a short-lived staging area whose only job is to
+produce exactly one model via `Build()`. The produced model is independent
+of the builder — they do not share lifetime. Examples:
+`ProcessConfigurationBuilder`, `ArgumentsBuilder`, `EnvironmentVariablesBuilder`,
+`UserCredentialBuilder`.
+
+A **Configuration Model** is an immutable, value-bearing object that
+describes one aspect of how a process should be run. Models in this
+library are POCOs: they hold data, expose read-only properties, and
+implement value equality. Examples: `ProcessConfiguration`,
+`ProcessExitConfiguration`, `UserCredential`, `ProcessTimeoutPolicy`,
+`ProcessResourcePolicy`.
+
+An **Invoker** is the abstraction that turns a configuration model into a
+running process. The default implementation, `ProcessInvoker`, wires
+together configuration, exit behaviour, cancellation, and piping, and
+returns a `ProcessResult`. The invoker owns nothing about the
+configuration; it reads the model, runs the process, and disposes the
+OS resources it allocated.
+
+A **Result** is the immutable object returned by the invoker after the
+process exits. Three concrete result types exist —
+`ProcessResult`, `BufferedProcessResult`, and `PipedProcessResult` —
+corresponding to the three execution modes (Basic, Buffered, Piped).
+Results are the canonical return value of the pipeline.
+
+A **Process Invocation Pipeline** is the layered interceptor pattern that
+CliInvoke uses to execute cross-cutting concerns around the core process
+orchestration. The pipeline wraps `IExternalProcess` and lets each
+cross-cutting concern modify the configuration before execution or the
+result after execution.
+
+A **Process Invocation Context** is the conceptual state-bearing object
+that moves through the pipeline. It encapsulates the requested
+configuration, the execution mode (Basic, Buffered, or Piped), the
+runner configuration (if any), and the resulting process output. Each
+cross-cutting concern reads from and writes to the context, and the
+context is the single source of truth that travels from the start of
+the pipeline to the end.
+
+A **Resource-Owning Type** is any CliInvoke type that holds, directly or
+transitively, an unmanaged resource (pipes, file handles, process
+threads) or a sensitive managed resource (`SecureString`). The library
+exposes exactly five; see the
+[Resource Disposal guide](resource-disposal.md) for the full list.
+
+## The data-flow: Builder → Model → Invoker → Result
+
+Every CliInvoke invocation moves through four stages, regardless of which
+pattern the caller uses.
+
+```text
+   ┌────────────┐   Build()   ┌──────────────────┐  ExecuteAsync   ┌──────────┐
+   │  Builder   │ ──────────► │  Configuration   │ ──────────────► │ Invoker  │
+   │ (mutable)  │             │      Model       │                 │ (executes)│
+   └────────────┘             │   (immutable)    │                 └────┬─────┘
+                              └──────────────────┘                      │
+                                                                        ▼
+                              ┌──────────────────┐   await    ┌──────────────────┐
+                              │ Process Result   │ ◄────────── │   Pipeline +     │
+                              │   (immutable)    │             │   IExternalProcess│
+                              └──────────────────┘             └──────────────────┘
+```
+
+```mermaid
+flowchart LR
+    A[Builder<br/>fluent, mutable] -->|Build()| B[Configuration Model<br/>immutable, value-equal]
+    B -->|ExecuteAsync| C[Invoker<br/>ProcessInvoker]
+    C -->|StartAsync| D[Pipeline + IExternalProcess]
+    D -->|await| E[Process Result<br/>immutable]
+    E -->|returned| C
+```
+
+### Stage 1 — Builder
+
+The builder is the caller's staging area. It exposes `Set*` and
+`Configure*` methods that return `this` for chaining and terminate with
+a `Build()` method that returns the configuration model. The builder
+holds mutable state for the duration of the assembly; the moment
+`Build()` is called, the builder's job is done and the model is
+independent of it.
+
+Key types in this stage:
+
+- `ProcessConfigurationBuilder` — assembles `ProcessConfiguration`.
+- `ArgumentsBuilder` — assembles the argument list.
+- `EnvironmentVariablesBuilder` — assembles the environment-variable
+  dictionary.
+- `ProcessResourcePolicyBuilder` — assembles `ProcessResourcePolicy`.
+- `UserCredentialBuilder` — assembles `UserCredential`.
+
+**Invariant:** the builder is single-use-per-stage. Calling `Build()`
+produces a model; calling `Build()` again produces a *new* model
+(mutations between calls do not retroactively change models already
+produced). The builder is **not** required — every model also exposes
+a public constructor — but it is the recommended way to assemble
+configurations with many optional properties.
+
+### Stage 2 — Configuration Model
+
+`Build()` returns an immutable, value-equal `ProcessConfiguration`. The
+model is the single thing that travels from the caller's code into the
+library's execution layer. It is read by the invoker and by every
+cross-cutting concern in the pipeline; nothing in the library is allowed
+to mutate it after construction.
+
+Key types in this stage:
+
+- `ProcessConfiguration` — the top-level model that the invoker
+  consumes. Owns the executable path, arguments, working directory,
+  environment, resource policy, timeout policy, and optional credential.
+- `ProcessExitConfiguration` — how the process should be terminated if
+  it does not exit on its own.
+- `UserCredential` — optional credentials for processes that require
+  them.
+
+**Invariants:**
+
+- Models are immutable after `Build()` returns.
+- The same model can be reused across multiple invocations; it carries
+  no per-call state.
+- The caller that constructed the model owns its lifetime and is
+  responsible for disposing it (it is one of the five
+  [Resource-Owning Types](resource-disposal.md#the-five-disposable-types)).
+
+### Stage 3 — Invoker
+
+The invoker is the abstraction that turns a `ProcessConfiguration` into
+a running process. The default implementation, `ProcessInvoker`, takes
+a configuration, a `ProcessExitConfiguration`, and a cancellation
+token; creates an `IExternalProcess` via the configured
+`IExternalProcessFactory`; runs it; and returns a typed result. Three
+methods exist on the interface, one per execution mode:
+
+- `ExecuteAsync` — returns `ProcessResult` (exit code only).
+- `ExecuteBufferedAsync` — returns `BufferedProcessResult` (exit code
+  plus captured `StandardOutput` / `StandardError` as strings).
+- `ExecutePipedAsync` — returns `PipedProcessResult` (exit code plus
+  live `StandardOutput` / `StandardError` streams).
+
+**Invariants:**
+
+- The invoker does not retain a reference to the configuration after
+  the invocation returns.
+- The invoker disposes the `IExternalProcess` it created — but it does
+  **not** dispose the configuration or the result. The caller owns
+  those.
+- The invoker reads the configuration, the exit configuration, and the
+  cancellation token; it does not read or write process state between
+  `Start` and exit (that is what `IExternalProcess` is for).
+
+### Stage 4 — Result
+
+The invoker returns a result. The result is the canonical return value
+of an invocation. It is immutable and, for the `Piped` variant, holds
+live streams that the caller must dispose (see
+[Resource Disposal → `PipedProcessResult`](resource-disposal.md#3-pipedprocessresult)).
+
+The result carries the `Process Invocation Context` state that the
+cross-cutting concerns wrote to: the runner configuration (if any), the
+captured output, the exit code, and any validation outcome.
+
+## Mapping the three patterns onto the data-flow
+
+The four-stage data-flow is invariant. What varies between the three
+patterns is **which stages the caller drives directly and which the
+library hides**.
+
+```mermaid
+flowchart LR
+    subgraph CLIRUN["CliRun (static facade)"]
+        C1[Stage 1: Builder] --> C2[Stage 2: Model]
+        C2 --> C3[Stage 3: Invoker]
+        C3 --> C4[Stage 4: Result]
+    end
+    subgraph INVOKER["IProcessInvoker (DI-friendly)"]
+        I1[Stage 2: Model<br/>caller-built] --> I2[Stage 3: Invoker<br/>resolved from DI]
+        I2 --> I3[Stage 4: Result]
+    end
+    subgraph EXT["IExternalProcess (power user)"]
+        E1[Stage 2: Model<br/>caller-built] --> E2[Stage 3a: IExternalProcessFactory.Create]
+        E2 --> E3[Stage 3b: IExternalProcess.StartAsync]
+        E3 --> E4[Stage 3c: caller interacts]
+        E4 --> E5[Stage 3d: IExternalProcess.CaptureResult]
+        E5 --> E6[Stage 4: Result]
+    end
+```
+
+### `CliRun` — drives every stage for the caller
+
+`CliRun` is a static façade. The caller hands it the executable, the
+arguments, and any optional knobs; `CliRun` runs Stages 1–3 internally
+using sensible defaults and returns the result.
+
+```csharp
+// Caller writes one line. CliRun does the rest.
+BufferedProcessResult result = await CliRun.RunBufferedAsync(
+    "dotnet", "--version");
+```
+
+Internally, `CliRun` constructs a `ProcessConfigurationBuilder`,
+configures it from the method arguments, calls `Build()` (Stage 1 →
+Stage 2), constructs an `ExternalProcessFactory` (or uses the one
+configured via `UseExternalProcessFactory` / `UseFilePathResolver`),
+delegates to a `ProcessInvoker` (Stage 3), and returns the result
+(Stage 4).
+
+The caller never sees the builder, the model, or the invoker. This is
+the trade-off documented in
+[Choosing your Invocation Pattern](choosing-invocation-pattern.md#cirun--quickstart-scripting):
+zero boilerplate, zero testability, zero customisation.
+
+### `IProcessInvoker` — caller provides Stages 1–2; library runs 3–4
+
+`IProcessInvoker` is the abstraction for DI-centric applications. The
+caller assembles the `ProcessConfiguration` themselves (Stage 1 →
+Stage 2), resolves the invoker from the container, and hands the
+configuration to the invoker (Stage 3). The invoker runs the process
+and returns the result (Stage 4).
+
+```csharp
+IProcessInvoker invoker = provider.GetRequiredService<IProcessInvoker>();
+
+using ProcessConfiguration config = new(
+    "dotnet", "--info", OutputRedirectionMode.Buffer);
+
+BufferedProcessResult result = await invoker.ExecuteBufferedAsync(
+    config, ProcessExitConfiguration.CreateGraceful());
+```
+
+The caller now has control over the model — they can construct it
+explicitly, share it across invocations, and inject a mock invoker for
+unit tests. They have given up `CliRun`'s one-liner simplicity, in
+exchange for testability and per-call configuration.
+
+### `IExternalProcess` — caller provides Stages 1–2; library and caller share 3; library returns 4
+
+`IExternalProcess` is the power-user API. The caller still assembles
+the configuration (Stages 1–2) but the "Invoker" stage is split into
+multiple sub-stages that the caller drives:
+
+1. `factory.CreateExternalProcess(config)` — Stage 3a: the library
+   creates the `IExternalProcess`.
+2. `process.StartAsync()` — Stage 3b: the library starts the OS
+   process.
+3. **The caller interacts with the process** — Stage 3c: write to
+   `StandardInput`, read from `StandardOutput`, send signals, check
+   status. This is the gap that no other pattern exposes.
+4. `process.CaptureBufferedResultAsync()` or
+   `CapturePipedResultAsync()` — Stage 3d: the library captures the
+   result and returns it.
+
+```csharp
+IExternalProcessFactory factory =
+    provider.GetRequiredService<IExternalProcessFactory>();
+
+using ProcessConfiguration config = new(
+    "dotnet", "--runtime", OutputRedirectionMode.Buffer);
+using IExternalProcess process = factory.CreateExternalProcess(config);
+
+await process.StartAsync();
+
+// ← The caller can pipe input, monitor progress, etc. here.
+
+BufferedProcessResult result = await process.CaptureBufferedResultAsync(
+    CancellationToken.None);
+```
+
+This is the only pattern that lets the caller do work between
+`Start` and `Capture`. The trade-off is significant: the caller owns
+the full `using` chain, the cancellation tokens, and the disposal
+contract for both the configuration and the `IExternalProcess`.
+
+### Where each pattern enters and exits
+
+| Pattern | Stage 1 (Builder) | Stage 2 (Model) | Stage 3 (Invoker / Process) | Stage 4 (Result) |
+|---|---|---|---|---|
+| `CliRun` | Library (implicit) | Library (implicit) | Library (default invoker) | Library returns |
+| `IProcessInvoker` | Caller | Caller | Library (resolved from DI) | Library returns |
+| `IExternalProcess` | Caller | Caller | Library + caller share | Library returns |
+
+## The Process Invocation Pipeline
+
+The **Process Invocation Pipeline** is the layered pattern CliInvoke
+uses to execute cross-cutting concerns around the core process
+orchestration. The pipeline wraps the `IExternalProcess` invocation
+and lets each concern modify the configuration before execution, or
+the result after execution, without entangling those concerns with
+the core `Start` → `Run` → `Capture` sequence.
+
+The state that travels through the pipeline is the **Process
+Invocation Context**: a conceptual bundle of the
+`ProcessConfiguration` (input), the execution mode (Basic, Buffered,
+or Piped), the runner configuration (if any), and the resulting
+`ProcessResult` (output). Each cross-cutting concern reads from and
+writes to this context, and the context is the single source of
+truth that flows from start to finish.
+
+```text
+        ┌─────────────────────────────────────────────────────────┐
+        │              Process Invocation Context                │
+        │  ┌──────────────────┐         ┌────────────────────┐    │
+        │  │ Process          │         │  Process Result    │    │
+        │  │ Configuration    │ ──────► │  (built up by      │    │
+        │  │ (immutable)      │         │   each stage)      │    │
+        │  └──────────────────┘         └────────────────────┘    │
+        │  Execution mode: Basic / Buffered / Piped               │
+        │  Runner configuration: optional                          │
+        └─────────────────────────────────────────────────────────┘
+                                  │
+        ┌─────────────────────────┼──────────────────────────────┐
+        │                         ▼                              │
+        │  ┌─────────┐  ┌────────────┐  ┌──────────────┐         │
+        │  │ Path    │  │   Runner   │  │   Result     │         │
+        │  │ Resolver│→ │  Wrap      │→ │ Validator    │  ... →  │
+        │  └─────────┘  └────────────┘  └──────────────┘         │
+        │     ▲                                                  │
+        │     │                                                  │
+        │  ┌──┴─────────┐                                        │
+        │  │ IExternalProcess │  ← Core execution                │
+        │  └──────────────────┘                                  │
+        └─────────────────────────────────────────────────────────┘
+```
+
+### The built-in cross-cutting concerns
+
+CliInvoke ships three first-class cross-cutting concerns. Each is
+backed by a public interface so that callers can replace or extend
+the default implementation.
+
+#### 1. Path resolution — `IFilePathResolver`
+
+`IFilePathResolver` answers the question *“where on disk is this
+executable?”*. The default implementation, `FilePathResolver`,
+consults `PATH` first, then falls back to directory recursion. The
+resolver is consulted by `ExternalProcessFactory` when the
+`ProcessConfiguration` references a bare executable name rather than
+an absolute path.
+
+Customising the resolver is the supported way to add new lookup
+strategies — for example, looking up executable paths in a vendored
+toolchain directory. See
+[`CONTEXT.md` § 1 — Resolution order rationale](https://github.com/alastairlundy/CliInvoke/blob/main/CONTEXT.md#1-resolution-order-rationale)
+for the performance contract that custom resolvers must respect.
+
+#### 2. Runner wrapping — `IRunnerConfigurationFactory`
+
+`IRunnerConfigurationFactory` answers the question *“if the process
+needs to be run through another process (e.g. PowerShell, CMD, or a
+custom shell), how do we build a new configuration that does that?”*.
+`CliInvoke.Specializations` provides implementations that wrap
+configurations for Windows PowerShell and CMD; custom implementations
+can wrap configurations for any other runner.
+
+The runner factory is consulted by the invoker when the configuration
+specifies that it must be executed through a runner. It rewrites the
+`ProcessConfiguration` accordingly; the rest of the pipeline then
+runs the rewritten configuration as if it were the original.
+
+#### 3. Result validation — `IProcessResultValidator`
+
+`IProcessResultValidator<TProcessResult>` answers the question
+*“is this result acceptable, or should we raise a failure?”*. The
+default implementation evaluates a set of `Func<TProcessResult, bool>`
+rules; if any rule returns `false`, the result is considered invalid.
+The invoker raises a `ProcessNotSuccessfulException` when a validator
+configured for "must succeed" mode returns invalid.
+
+Custom validators are the supported way to add domain-specific
+post-execution checks — for example, asserting that captured output
+matches a regex, or that a specific environment variable was
+forwarded.
+
+### Where the pipeline sits in the data-flow
+
+The pipeline wraps the `IExternalProcess` stage. The path resolver
+runs **before** the process is created (it resolves the executable
+path that `ExternalProcess` will use); the runner factory runs
+**before** the process is created (it rewrites the configuration
+when a runner is in play); the result validator runs **after** the
+process exits (it inspects the result before it is returned).
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Invoker as ProcessInvoker
+    participant Pipeline as Pipeline (path → runner → core)
+    participant Process as IExternalProcess
+    participant Validator as IProcessResultValidator
+
+    Caller->>Invoker: ExecuteAsync(config)
+    Invoker->>Pipeline: Create IExternalProcess(config)
+    Pipeline->>Pipeline: IFilePathResolver.Resolve(config)
+    Pipeline->>Pipeline: IRunnerConfigurationFactory.MaybeRewrite(config)
+    Pipeline->>Process: new IExternalProcess(rewritten config)
+    Pipeline-->>Invoker: IExternalProcess
+    Invoker->>Process: StartAsync()
+    Process-->>Invoker: started
+    Invoker->>Process: WaitForExit / Capture
+    Process-->>Invoker: result
+    Invoker->>Validator: Validate(result)
+    Validator-->>Invoker: ok | throw
+    Invoker-->>Caller: result
+```
+
+### Why a pipeline
+
+The pipeline keeps the core execution path (`Start` → `Run` →
+`Capture` → `Dispose`) free of cross-cutting logic. A new
+cross-cutting concern — for example, distributed-tracing context
+propagation, or per-call metric emission — can be added by writing
+a new interceptor without modifying the invoker or the
+`IExternalProcess` interface. Callers who need to disable a
+default concern can do so by registering an alternative
+implementation through `CliInvoke.Extensions`.
+
+## Where to customise
+
+The pipeline exposes three public extension points. All three are
+documented in the
+[API Reference](../api/), and the cross-cutting concerns page in the
+API reference is the canonical place to look up method signatures.
+
+| Concern | Public interface | Default implementation | Replace via |
+|---|---|---|---|
+| Path resolution | `IFilePathResolver` | `FilePathResolver` | `UseCustomFilePathResolver<T>(ServiceLifetime)` |
+| Runner wrapping | `IRunnerConfigurationFactory` | (none — opt-in) | `RunnerConfigurationFactory` (CliInvoke.Specializations) |
+| Result validation | `IProcessResultValidator<TProcessResult>` | `ProcessResultValidator<TProcessResult>` | `AddCustomResultValidators(...)` |
+
+The **core execution** layer — `IExternalProcess`, `ProcessInvoker`,
+`ExternalProcessFactory` — is not intended to be replaced for
+ordinary use. If you find yourself wanting to override the core
+executor, treat that as a signal that you may need a new pattern
+rather than a pipeline extension; open an issue describing the
+scenario.
+
+## Further reading
+
+- [Choosing your Invocation Pattern](choosing-invocation-pattern.md) —
+  the decision tree for picking between `CliRun`, `IProcessInvoker`,
+  and `IExternalProcess`.
+- [Configuration](configuration.md) — the full reference for
+  `ProcessConfiguration`, the builder lifecycle, and the
+  default-value appendix.
+- [Resource Disposal](resource-disposal.md) — the disposal contract
+  for the five Resource-Owning Types, including the configuration,
+  the `IExternalProcess`, and the result.
+- [Troubleshooting](troubleshooting.md) — symptom-based diagnosis for
+  leaks, hangs, exit-code mismatches, and file-not-found errors.
+- [`PATTERNS.md`](https://github.com/alastairlundy/CliInvoke/blob/main/PATTERNS.md) — full API-level detail for
+  the three invocation patterns.
+- [`CONTEXT.md`](https://github.com/alastairlundy/CliInvoke/blob/main/CONTEXT.md) — the canonical glossary,
+  including the definitions of the Process Invocation Pipeline and
+  the Process Invocation Context.
+
+

--- a/site/readme.md
+++ b/site/readme.md
@@ -4,156 +4,132 @@ layout: simple
 og_type: website
 ---
 
-# New Website Quickstart
+# CliInvoke
 
-This is the default landing page created by `lunet init`.
+CliInvoke is a .NET library for running and interacting with external
+command-line processes. It is built for .NET developers who need to launch
+an executable, redirect its standard streams, capture its output, and reason
+about its lifetime — without hand-rolling `System.Diagnostics.Process` for
+every project.
 
-Use it as a setup checklist, then replace it with your real homepage content.
+## What CliInvoke is
 
-## 1) Edit `config.scriban`
+Every .NET codebase that shells out to another tool eventually needs the same
+things: a way to describe the command, a way to start it, a way to capture
+its output, a way to dispose of its handles, and a way to test the code that
+does all of that. `System.Diagnostics.Process` provides the primitives; the
+boilerplate — pipe setup, output buffering, exit-code handling, disposal,
+thread-safety, cross-platform path lookup — is left to you. CliInvoke
+provides the layer on top.
 
-Your site already references the [default Lunet template](https://github.com/lunet-io/templates). Open `config.scriban` and set your project values:
+The library targets .NET 8, .NET 9, and .NET 10, runs on Windows, macOS,
+Linux, and BSD, and ships with first-class dependency-integration helpers
+through `CliInvoke.Extensions`.
 
-```scriban
-extend "lunet-io/templates"
+## What it offers
 
-site_project_name = "MyProject"
-site_project_description = "Short project description."
-site_project_baseurl = "https://example.com"
-site_project_github_user = "org"
-site_project_github_repo = "myproject"
-site_project_owner_name = "Your Name"
+CliInvoke exposes **three invocation patterns** that cover the spectrum from
+scripting to long-running process control:
 
-# Optional - set a logo, social banner, favicon, etc.:
-# site_project_logo_path = "/img/myproject-logo.png"
-# site_project_social_banner_path = "/img/myproject-banner.png"
-# site_project_banner_background_path = "/img/myproject-banner-background.png"
-# site_project_favicon_path = "/favicon.ico"
-# site_project_basepath = "/myproject"  # only if hosted under a sub-path
+- **[`CliRun`](docs/guides/choosing-invocation-pattern.md#cirun--quickstart-scripting)** —
+  a static façade for one-line command execution. The right entry point when
+  you just need to run a command and read its output.
+- **[`IProcessInvoker`](docs/guides/choosing-invocation-pattern.md#iprocessinvoker--di-centric-applications)** —
+  an interface for DI-centric applications. Takes a `ProcessConfiguration`
+  and returns a typed result, with full support for test doubles and per-call
+  configuration.
+- **[`IExternalProcess`](docs/guides/choosing-invocation-pattern.md#iexternalprocess--power-user-lifecycle-control)** —
+  a power-user API for granular lifecycle control. Splits start, capture,
+  and kill into separate calls so you can interact with the process while
+  it runs.
 
-site_project_init
-```
+Underneath those patterns sit the capabilities that make the library
+practical to use day-to-day:
 
-Notes:
+- **Configuration builders and models** — fluent builders assemble
+  immutable `ProcessConfiguration` and `ProcessExitConfiguration` models
+  with sensible defaults. See the
+  [Configuration guide](docs/guides/configuration.md) for the full
+  reference.
+- **Resource disposal** — five
+  [Resource-Owning Types](docs/guides/resource-disposal.md) own every
+  unmanaged handle and `SecureString` buffer; the
+  [Resource Disposal guide](docs/guides/resource-disposal.md) documents
+  the disposal contract for each one.
+- **Cross-platform support** — Windows, macOS, Linux, and BSD with
+  consistent behaviour; see
+  [Supported Operating Systems](docs/Supported-OperatingSystems.md).
+- **Dependency-injection extensions** — `AddCliInvoke()` registers the
+  invoker, factory, and file-path resolver with the container of your
+  choice. See
+  [Getting Started](docs/getting-started.md#setting-up-cliinvoke).
+- **Specializations** — first-class wrappers for running commands through
+  PowerShell or CMD on Windows via
+  [`CliInvoke.Specializations`](https://www.nuget.org/packages/CliInvoke.Specializations).
 
-- `site_project_logo_path` defaults to the Lunet logo if not set.
-- Favicon defaults to `/favicon.ico`. Keep a file there, or override `site_project_favicon_path`.
+If you are unsure which pattern fits your scenario, the
+[Choosing your Invocation Pattern](docs/guides/choosing-invocation-pattern.md)
+guide walks through the decision tree and the trade-offs of each option.
 
-### Theme defaults
+## Where to go next
 
-```scriban
-template_theme_default_mode = "system" # system, light, dark
-template_theme_storage_key = "lunet-theme"
-```
+Different readers arrive here with different needs. Pick the path that
+matches yours and follow it in order.
 
-Use the navbar theme button to switch mode at runtime.
+### If you are new to CliInvoke
 
-## Theme configuration and customization
+Start with a runnable example, then read the pattern-decision guide.
 
-The template provides layouts, CSS/JS assets, a theme switcher, search, and more. Treat theme internals as read-only - customize through your own files and `config.scriban` only.
+1. [Quickstart](docs/getting-started-quickstart.md) — install the package
+   and run your first `CliRun` command in under five minutes.
+2. [Choosing your Invocation Pattern](docs/guides/choosing-invocation-pattern.md)
+   — the decision tree for picking between `CliRun`, `IProcessInvoker`,
+   and `IExternalProcess`.
+3. [Configuration](docs/guides/configuration.md) — every knob on
+   `ProcessConfiguration` and `ProcessExitConfiguration`.
 
-### Naming conventions
+### If you are building a testable app with DI
 
-- `site_project_*`: **project inputs** you set in your `config.scriban` (name, repo, owner, assets…).
-- `template_*`: **theme customization** knobs (labels, theme mode, extra override styles…).
-- `project_*`: **resolved values** computed by `site_project_init` (don't set these manually).
-- Lunet core variables like `baseurl`, `basepath`, `title`, `description`, `author` are set by `site_project_init`.
+You work in a codebase that uses dependency injection and you need to
+unit-test code that shells out to processes.
 
-### Theme variables
+1. [Getting Started](docs/getting-started.md#setting-up-cliinvoke) —
+   register `IProcessInvoker` with your DI container.
+2. [Choosing your Invocation Pattern](docs/guides/choosing-invocation-pattern.md)
+   — confirm `IProcessInvoker` is the right pattern for your scenario.
+3. [Configuration](docs/guides/configuration.md) — the
+   `ProcessConfiguration` model, the builder lifecycle, and the
+   default-value reference appendix.
 
-Set these before calling `site_project_init`:
+### If you need full lifecycle control
 
-{.table}
-| Variable | Type | Default | Meaning |
-|---|---:|---:|---|
-| `template_theme_default_mode` | string | `"system"` | Initial theme mode (`"system"`, `"light"`, `"dark"`). |
-| `template_theme_storage_key` | string | `"lunet-theme"` | LocalStorage key used by the theme switcher. |
-| `template_theme_override_styles` | list of strings | `[]` | Site-owned stylesheet paths bundled **after** the theme CSS. |
+You need to interact with the process while it runs — pipe input, monitor
+output, send signals, or replace components for advanced scenarios.
 
-### Project variables
+1. [Choosing your Invocation Pattern](docs/guides/choosing-invocation-pattern.md)
+   — when and how to use the `IExternalProcess` factory and lifecycle
+   API.
+2. [Architecture](docs/guides/architecture.md) — the internal data-flow
+   and the Process Invocation Pipeline so you can reason about where a
+   customisation belongs.
+3. [Resource Disposal](docs/guides/resource-disposal.md) — the disposal
+   contract for the five Resource-Owning Types, including
+   `IExternalProcess` and `PipedProcessResult`.
 
-{.table}
-| Variable | Example | Used for |
-|---|---:|---|
-| `site_project_name` | `"MyProject"` | Site title/branding. |
-| `site_project_description` | `"Short description"` | Homepage and social metadata. |
-| `site_project_logo_path` | `"/img/myproject-logo.png"` | Navbar logo. |
-| `site_project_social_banner_path` | `"/img/myproject-banner.png"` | Social/OG image. |
-| `site_project_banner_background_path` | `"/img/myproject-banner.png"` | Homepage banner background. |
-| `site_project_package_id` | `"MyProject"` | Package display/links. |
-| `site_project_baseurl` | `"https://example.com"` | Canonical URL for `lunet build`. |
-| `site_project_github_user` | `"org"` | GitHub org/user. |
-| `site_project_github_repo` | `"myproject"` | GitHub repo name. |
-| `site_project_basepath` | `"/myproject"` | Base path (sub-path hosting). |
-| `site_project_favicon_path` | `"/favicon.ico"` | Favicon path. |
-| `site_project_owner_name` | `"Your Name"` | Footer ownership + author. |
-| `site_project_owner_alias` | `"your-handle"` | Footer ownership alias. |
-| `site_project_owner_url` | `"https://example.com"` | Footer ownership link. |
-| `site_project_content_license_name` | `"CC BY 2.5"` | Footer content license. |
-| `site_project_content_license_url` | `"http://creativecommons.org/licenses/by/2.5/"` | License link. |
-| `site_project_twitter_user` | `"your-handle"` | Twitter card metadata. |
+### If you have a specific task
 
-### Custom styles
+If you know what you need to accomplish but not which page it lives on,
+jump straight to the relevant guide.
 
-Add `template_theme_override_styles` to load your own CSS/SCSS after the theme:
+| I want to … | Go to |
+|---|---|
+| Debug a leak, hang, or wrong exit code | [Troubleshooting](docs/guides/troubleshooting.md) |
+| Tune how a process starts or exits | [Configuration](docs/guides/configuration.md) |
+| Understand the internal data-flow | [Architecture](docs/guides/architecture.md) |
+| Pick between `CliRun`, `IProcessInvoker`, and `IExternalProcess` | [Choosing your Invocation Pattern](docs/guides/choosing-invocation-pattern.md) |
+| Dispose the Resource-Owning Types correctly | [Resource Disposal](docs/guides/resource-disposal.md) |
+| Install and set up the library | [Getting Started](docs/getting-started.md) · [Quickstart](docs/getting-started-quickstart.md) |
+| Look up a specific API | [API Reference](api/) |
 
-```scriban
-template_theme_override_styles = ["/css/theme-overrides.scss"]
-```
-
-Then create `css/theme-overrides.scss` in your site folder:
-
-```scss
-:root[data-bs-theme="dark"] {
-  --lunet-color-background: #0b1020;
-  --lunet-color-blue: #6ea8ff;
-  --lunet-code-bg: #0b1426;
-}
-```
-
-The theme exposes `--lunet-*` CSS custom properties for colors, code highlighting, and more. Override these instead of targeting internal selectors.
-
-## 2) Edit navigation
-
-### Top bar (`menu.yml`)
-
-Your site includes a `menu.yml` with Home and Docs entries. Add right-side links:
-
-```yml
-home:
-  - {path: readme.md, title: "<i class='bi bi-house-door' aria-hidden='true'></i> Home", self: true}
-  - {path: docs/readme.md, title: "<i class='bi bi-book' aria-hidden='true'></i> Docs", folder: true}
-
-home2:
-  - {url: "https://github.com/org/repo/", title: '<i class="bi bi-github"></i> GitHub', link_class: btn btn-info}
-```
-
-### Docs sidebar (`docs/menu.yml`)
-
-Add pages to the docs section:
-
-```yml
-doc:
-  - {path: readme.md, title: "<i class='bi bi-book' aria-hidden='true'></i> Documentation"}
-  - {path: getting-started.md, title: "<i class='bi bi-rocket-takeoff' aria-hidden='true'></i> Getting Started"}
-```
-
-## 3) Replace this homepage
-
-This `readme.md` is the homepage (`/`). Keep the front matter and replace the body with your project content.
-
-## Build locally
-
-```shell-session
-lunet serve
-```
-
-Your site is live at `http://localhost:4000`. Edit pages and see changes reload instantly.
-
-Build for production:
-
-```shell-session
-lunet build
-```
-
-Output goes to `.lunet/build/www/`.
+For a flat index of every page, see the
+[Documentation hub](docs/readme.md).


### PR DESCRIPTION
## What changed

- Replaced the `lunet init` placeholder landing page in `site/readme.md` with a real one organised as three blocks: *What CliInvoke is*, *What it offers*, and *Where to go next*.
- Replaced the Lunet default `site_project_description` in `site/config.scriban` with a one-line description of CliInvoke (was leaking into social previews and meta tags).
- Added `site/docs/guides/architecture.md`, a new ~490-line end-to-end architecture guide covering the high-level goals, the core terminology (Process Invocation Pipeline, Process Invocation Context, etc.), the four-stage data flow with an ASCII diagram, a Mermaid diagram of how that flow maps to the three invocation patterns (CliRun, IProcessInvoker, IExternalProcess), the full Process Invocation Pipeline, a sequence diagram of a single run, a customisation matrix, and a further reading list that points at `CONTEXT.md` and `PATTERNS.md` for canonical definitions. Three Mermaid diagrams and one ASCII diagram in total.


## Why it was changed

The current site landing page is the boilerplate produced by `lunet init` and tells visitors almost nothing about what CliInvoke is or why they should care. The site also lacks a top-level architecture guide even though `CONTEXT.md` and `PATTERNS.md` already document the underlying concepts at a lower level. This PR fixes both gaps so the site gives a clearer first impression and gives readers an end-to-end architectural map to navigate from.

**Notable choices worth flagging:**

- **Cross-references to repo-root files use GitHub blob URLs, not relative paths.** A link like `../../../CONTEXT.md` from `site/docs/guides/architecture.md` causes `lunet build` to throw `System.ArgumentException: The path '/docs/guides/../../../CONTEXT.md' cannot go to the parent (..) of a root path /`. This is a pre-existing issue - `site/docs/guides/choosing-invocation-pattern.md` (PR #352) has the same defect and `lunet build` already fails for that file on `main`. The same workaround is already used in `site/docs/readme.md` and `site/docs/building-cliinvoke.md`. A follow-up should either fix the relative links in `choosing-invocation-pattern.md` or, preferably, fix the link resolution in lunet itself.
- **Diagrams use Mermaid for everything except one ASCII data-flow diagram.** Mermaid blocks render in the same simple layout used by the other guides, no extra config needed. The ASCII data-flow diagram is included inline because box-drawing characters stay readable in source and do not require JS to render.


## Testing

N/A - this PR is documentation-only. No production code, tests, or public APIs were changed, so there is no `dotnet test` surface to exercise.

- [ ] `dotnet test` passes locally on the supported TFMs
- [ ] New or updated tests are included for the change
- [ ] Behavior-affecting changes are covered by tests

## Documentation

- [x] README, docs/, or XML doc comments updated (if applicable)
- [ ] VERSION_HISTORY.md updated (if user-visible)
- [ ] No docs change needed

## Contribution Policy compliance

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [x] My branch is up to date with `main` and the diff is focused
- [x] Commit messages are clear and describe the change
- [x] I have not introduced secrets, credentials, or copyrighted content
- [ ] For changes that affect resource-owning types, I followed the
      disposal conventions in the README

## Authorship

- [ ] This PR was written entirely by a human (no AI assistance)
- [x] This PR was Co-Authored by AI (the human author reviewed,
      edited, and takes responsibility for the final code; commits
      include the appropriate `Co-authored-by:` trailer(s))

If this PR was Co-Authored by AI, please also fill in the following:

- **AI agent used:** GitHub Copilot CLI
- **AI model used:** minimax-m3