### PR TITLE
Scale graceful cancel wait with timeout (main port of #380)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,8 @@ exit-handling strategy:
 - `ProcessExitBehaviour.GracefulExit` → race a `Task.Delay` against
   `WaitForExitAsync`; on timeout, send an interrupt signal via
   `BaseProcessControlAdapter.SendInterruptSignalAsync`; after a
-  500 ms grace period, fall back to `Kill()`.
+  `CalculateGracefulTimeoutWaitSeconds(timeoutSeconds)` grace period
+  (10s + 5% of the timeout, capped at 20s), fall back to `Kill()`.
 - `ProcessExitBehaviour.ForcefulExit` → `Kill()` after the timeout.
 
 The race is serialised by a `SemaphoreSlim`

--- a/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
+++ b/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
@@ -15,12 +15,26 @@ using CliInvoke.Processes.Internal.ControlAdapters;
 namespace CliInvoke.Processes.Internal;
 
 /// <summary>
-/// 
+///
 /// </summary>
 internal class ProcessWrapper : Process
 {
-    internal const int GracefulTimeoutWaitSeconds = 5;
-    
+    /// <summary>
+    /// Computes how long, in seconds, the graceful cancellation path should wait after the
+    /// timeout threshold before giving up on the interrupt signal and falling back to
+    /// (optionally) a forceful exit.
+    /// </summary>
+    /// <param name="timeoutSeconds">The user-supplied timeout threshold, in whole seconds.</param>
+    /// <returns>
+    /// <c>min(10 + floor(timeoutSeconds * 0.05), 20)</c> — i.e. a fixed 10s base plus 5% of the
+    /// requested timeout (rounded down to an integer), capped at 20s.
+    /// </returns>
+    internal static int CalculateGracefulTimeoutWaitSeconds(int timeoutSeconds)
+    {
+        int waitSeconds = 10 + (int)Math.Floor(timeoutSeconds * 0.05);
+        return Math.Min(waitSeconds, 20);
+    }
+
     // Synchronisation primitive to prevent simultaneous cancellation attempts
     internal readonly SemaphoreSlim _cancellationSemaphore = new(1, 1);
 
@@ -382,7 +396,11 @@ internal class ProcessWrapper : Process
             ]);
 
             await Task.WhenAny([
-                Task.Delay(500, cancellationToken), WaitForExitAsync(cancellationToken)
+                Task.Delay(
+                    TimeSpan.FromSeconds(
+                        CalculateGracefulTimeoutWaitSeconds((int)exitConfiguration.TimeoutPolicy.TimeoutThreshold.TotalSeconds)),
+                    cancellationToken),
+                WaitForExitAsync(cancellationToken)
             ]);
 
             if (!HasExited && fallbackToForceful) 

--- a/tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs
+++ b/tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs
@@ -34,7 +34,11 @@ public class GracefulCancellationTests
 
         long elapsedTimeSeconds = stopwatch.ElapsedMilliseconds / 1000;
 
-        await Assert.That(elapsedTimeSeconds).IsBetween(0, Math.Min(gracefulTimeoutSeconds * 3, 60));
+        int waitSeconds =
+            ProcessWrapper.CalculateGracefulTimeoutWaitSeconds(gracefulTimeoutSeconds);
+
+        await Assert.That(elapsedTimeSeconds)
+            .IsBetween(0, Math.Min(gracefulTimeoutSeconds + waitSeconds + 5, 60));
 
         await Assert.That(process.HasExited).IsTrue();
 


### PR DESCRIPTION
## Summary

Port the graceful-cancel wait-scaling rule from PR #380 (which targets `v2.9.x`) to `main`'s refactored structure, where `GracefulCancellation.cs` no longer exists. A literal diff isn't applicable: the analogous hard-code on `main` is a 500 ms `Task.Delay` inside `ProcessWrapper.WaitForExitOrGracefulTimeoutAsync`, and the existing `GracefulTimeoutWaitSeconds = 5` constant is unused.

The change is semantic, not textual: the post-interrupt grace period now scales with the configured timeout instead of being a fixed magic number. Formula, method name, and XML doc match #380 verbatim.

## Changes

- **`src/CliInvoke/Processes/Internal/ProcessWrapper.cs`**
  - Replaced the unused `internal const int GracefulTimeoutWaitSeconds = 5;` with `internal static int CalculateGracefulTimeoutWaitSeconds(int)`, returning `min(10 + floor(timeoutSeconds * 0.05), 20)`.
  - `WaitForExitOrGracefulTimeoutAsync` now uses the method to size the `Task.Delay` after the interrupt, replacing the hard-coded `Task.Delay(500, cancellationToken)`.

- **`tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs`**
  - Test elapsed-time upper bound now derived from the same formula: `timeoutSeconds + waitSeconds + 5`, capped at 60. Bound cannot drift from implementation.

- **`docs/architecture.md`**
  - Stage 3 `ProcessWrapper` description now references the new method instead of the hard-coded 500 ms grace period.

## Effect

| Timeout | Prior wait (after interrupt) | New wait |
| ------- | ---------------------------- | -------- |
| 0s      | 500 ms                       | 10s      |
| 10s     | 500 ms                       | 10s      |
| 60s     | 500 ms                       | 13s      |
| 200s    | 500 ms                       | 20s (capped) |

## Why this isn't a textual port

- `src/CliInvoke/Helpers/Processes/Cancellation/GracefulCancellation.cs` does not exist on `main`; graceful-cancel logic moved into `ProcessWrapper.cs`.
- The `GracefulTimeoutWaitSeconds` constant on `main` was set to `5` and is unused elsewhere.
- The analogous "grace period" on `main` is a hard-coded `Task.Delay(500, cancellationToken)`, not a `TimeSpan.FromSeconds(...)` offset.
- The test on `main` uses xUnit v3 `IsBetween` syntax (not `Assert.InRange`).

## Testing

- `dotnet build src/CliInvoke/` — succeeds on all TFMs (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`); only pre-existing XML-comment warnings.
- `dotnet test --no-build --project tests/CliInvoke.Tests/` — targeted `GracefulCancel_InterruptSignals_Success` passes on `net10.0` (the test project's sole TFM).
- Full suite: 107/108 pass. The single failure is `ProcessSuspendResumeTests.SuspendResume_Process_ShouldExitAfterResume`, a pre-existing race in `ProcessWrapper.Start()` line 106. Confirmed by stashing the changes, running on unmodified `main` (still failing), and restoring the branch. Out of scope here — same as PR #380.

## Caveats

- The test project only targets `net10.0` on `main`, so the suite was not run on `net8.0`/`net9.0`.
- On Windows, the test uses the `timeout /t /nobreak` command, which has its own behaviour; the bound itself is correct.

## Related

- #380 (v2.9.x): the original change. Not modified by this work.
- Future releases branching from either base will carry the same scaling rule.