### PR TITLE
fix: port WaitForExitAsync pipe EOF hang fix from PR 394 to v2.10.x

### DIFF
--- a/src/CliInvoke/Helpers/ProcessWrapper.cs
+++ b/src/CliInvoke/Helpers/ProcessWrapper.cs
@@ -71,6 +71,10 @@ internal
         {
             // Process may have exited between starting and applying policy
         }
+        catch (Win32Exception)
+        {
+            // Process may have exited between starting and applying resource policy
+        }
     }
 
     private void OnExited(object? sender, EventArgs e)
@@ -103,7 +107,15 @@ internal
         StartTime = DateTime.UtcNow;
         Started.Invoke(this, EventArgs.Empty);
         Id = base.Id;
-        ProcessName = base.ProcessName;
+        try
+        {
+            ProcessName = base.ProcessName;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process may have exited before ProcessName could be read
+            ProcessName = StartInfo.FileName;
+        }
 
         return HasStarted;
     }

--- a/src/CliInvoke/Helpers/ProcessWrapper.cs
+++ b/src/CliInvoke/Helpers/ProcessWrapper.cs
@@ -144,6 +144,31 @@ internal
         }
     }
 
+    /// <summary>
+    ///     Waits for the process to exit without blocking on stream EOF.
+    ///     <para>
+    ///     The base-class <see cref="Process.WaitForExitAsync(CancellationToken)"/> always calls
+    ///     <c>WaitUntilOutputEOF</c> after exit detection, which blocks indefinitely when
+    ///     redirected stdout/stderr pipes are held open by grandchild or unrelated processes
+    ///     (see dotnet/runtime#51277). This method avoids that by polling <see cref="Process.HasExited"/>
+    ///     via <see cref="Task.Delay(int, CancellationToken)"/>, which never blocks on stream EOF.
+    ///     </para>
+    /// </summary>
+    internal async Task WaitForExitSafeAsync(CancellationToken cancellationToken)
+    {
+        const int pollIntervalMs = 200;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (HasExited)
+                return;
+
+            await Task.Delay(pollIntervalMs, cancellationToken).ConfigureAwait(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
     // Windows: list threads and call SuspendThread/ResumeThread on each thread of the process.
 #if NET8_0_OR_GREATER
     [LibraryImport("kernel32.dll", SetLastError = true)]

--- a/src/CliInvoke/Helpers/Processes/Cancellation/ForcefulCancellation.cs
+++ b/src/CliInvoke/Helpers/Processes/Cancellation/ForcefulCancellation.cs
@@ -46,7 +46,7 @@ internal static class ForcefulCancellation
 
             try
             {
-                Task waitForExit = process.WaitForExitAsync(cancellationToken);
+                Task waitForExit = process.WaitForExitSafeAsync(cancellationToken);
                 Task delay = Task.Delay(timeoutThreshold, cancellationToken);
 
                 await Task.WhenAny(delay, waitForExit);

--- a/src/CliInvoke/Helpers/Processes/Cancellation/GracefulCancellation.cs
+++ b/src/CliInvoke/Helpers/Processes/Cancellation/GracefulCancellation.cs
@@ -63,7 +63,7 @@ internal static partial class GracefulCancellation
                 // Wait for any of the three tasks to complete
                 Task[] tasks =
                 [
-                    process.WaitForExitAsync(cancellationToken),
+                    process.WaitForExitSafeAsync(cancellationToken),
                     gracefulInterruptCancellation,
                     process.GracefulCancellationWithCancelToken(
                         timeoutThreshold + TimeSpan.FromSeconds(
@@ -126,7 +126,7 @@ internal static partial class GracefulCancellation
 
             try
             {
-                await process.WaitForExitAsync(cts.Token);
+                await process.WaitForExitSafeAsync(cts.Token);
             }
             catch (TaskCanceledException)
             {

--- a/src/CliInvoke/Helpers/Processes/ProcessCancellationExtensions.cs
+++ b/src/CliInvoke/Helpers/Processes/ProcessCancellationExtensions.cs
@@ -57,7 +57,7 @@ internal static class ProcessCancellationExtensions
         {
             try
             {
-                await process.WaitForExitAsync(cancellationToken);
+                await process.WaitForExitSafeAsync(cancellationToken);
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary

Ports the `WaitForExitAsync` pipe EOF hang fix from PR 394 to the v2.10.x branch, and fixes pre-existing race conditions in `ProcessWrapper.Start()`.

## Changes

### 1. WaitForExitAsync pipe EOF hang fix (from PR 394)
**Bug:** `Process.WaitForExitAsync()` blocks indefinitely when redirected stdout/stderr pipes are held open by grandchild or unrelated processes ([dotnet/runtime#51277](https://github.com/dotnet/runtime/issues/51277)).

**Fix:** Adds `WaitForExitSafeAsync` to `ProcessWrapper.cs` that polls `HasExited` via `Task.Delay(200)` instead of using the built-in `WaitForExitAsync()` which always calls `WaitUntilOutputEOF` after exit detection.

- **`src/CliInvoke/Helpers/ProcessWrapper.cs`** — Added `WaitForExitSafeAsync(CancellationToken)` method
- **`src/CliInvoke/Helpers/Processes/Cancellation/GracefulCancellation.cs`** — 2 call sites updated
- **`src/CliInvoke/Helpers/Processes/Cancellation/ForcefulCancellation.cs`** — 1 call site updated
- **`src/CliInvoke/Helpers/Processes/ProcessCancellationExtensions.cs`** — 1 call site updated

### 2. ProcessWrapper.Start() race condition fix
**Bug:** Windows `timeout` with redirected stdout exits immediately, causing two race conditions in `ProcessWrapper.Start()`:
1. `SetResourcePolicy` throws `Win32Exception` (Access is denied) when setting `PriorityBoostEnabled` on an already-exited process
2. `base.ProcessName` throws `InvalidOperationException` when the process exits before `ProcessName` can be read

**Fix:** Catch `Win32Exception` in `OnStarted`, and wrap `ProcessName` access in try-catch with fallback to `StartInfo.FileName`.

## Test Results

- **246/246 tests pass** across net8.0, net9.0, and net10.0 ✅

---

Co-authored-by: GitHub Copilot App (using MiMo V2.5)