### PR TITLE
fix: backport WaitForExitAsync pipe EOF hang fix to v2.9.x

### DIFF
--- a/src/CliInvoke/Helpers/ProcessWrapper.cs
+++ b/src/CliInvoke/Helpers/ProcessWrapper.cs
@@ -101,11 +101,46 @@ internal
         if (!HasStarted) return HasStarted;
         
         StartTime = DateTime.UtcNow;
-        Started.Invoke(this, EventArgs.Empty);
         Id = base.Id;
-        ProcessName = base.ProcessName;
+        Started.Invoke(this, EventArgs.Empty);
+
+        try
+        {
+            ProcessName = base.ProcessName;
+        }
+        catch (InvalidOperationException)
+        {
+            // Process may have exited between Start() and accessing ProcessName
+            // (e.g. Windows 'timeout' exits immediately when stdout is redirected).
+            ProcessName = StartInfo.FileName;
+        }
 
         return HasStarted;
+    }
+
+    /// <summary>
+    ///     Waits for the process to exit without blocking on stream EOF.
+    ///     <para>
+    ///     The base-class <see cref="Process.WaitForExitAsync(CancellationToken)"/> always calls
+    ///     <c>WaitUntilOutputEOF</c> after exit detection, which blocks indefinitely when
+    ///     redirected stdout/stderr pipes are held open by grandchild or unrelated processes
+    ///     (see dotnet/runtime#51277). This method avoids that by polling <see cref="Process.HasExited"/>
+    ///     via <see cref="Task.Delay(int, CancellationToken)"/>, which never blocks on stream EOF.
+    ///     </para>
+    /// </summary>
+    internal async Task WaitForExitSafeAsync(CancellationToken cancellationToken)
+    {
+        const int pollIntervalMs = 200;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (HasExited)
+                return;
+
+            await Task.Delay(pollIntervalMs, cancellationToken).ConfigureAwait(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <summary>

--- a/src/CliInvoke/Helpers/Processes/Cancellation/ForcefulCancellation.cs
+++ b/src/CliInvoke/Helpers/Processes/Cancellation/ForcefulCancellation.cs
@@ -46,7 +46,7 @@ internal static class ForcefulCancellation
 
             try
             {
-                Task waitForExit = process.WaitForExitAsync(cancellationToken);
+                Task waitForExit = process.WaitForExitSafeAsync(cancellationToken);
                 Task delay = Task.Delay(timeoutThreshold, cancellationToken);
 
                 await Task.WhenAny(delay, waitForExit);

--- a/src/CliInvoke/Helpers/Processes/Cancellation/GracefulCancellation.cs
+++ b/src/CliInvoke/Helpers/Processes/Cancellation/GracefulCancellation.cs
@@ -63,7 +63,7 @@ internal static partial class GracefulCancellation
                 // Wait for any of the three tasks to complete
                 Task[] tasks =
                 [
-                    process.WaitForExitAsync(cancellationToken),
+                    process.WaitForExitSafeAsync(cancellationToken),
                     gracefulInterruptCancellation,
                     process.GracefulCancellationWithCancelToken(
                         timeoutThreshold + TimeSpan.FromSeconds(
@@ -126,7 +126,7 @@ internal static partial class GracefulCancellation
 
             try
             {
-                await process.WaitForExitAsync(cts.Token);
+                await process.WaitForExitSafeAsync(cts.Token);
             }
             catch (TaskCanceledException)
             {

--- a/src/CliInvoke/Helpers/Processes/ProcessCancellationExtensions.cs
+++ b/src/CliInvoke/Helpers/Processes/ProcessCancellationExtensions.cs
@@ -57,7 +57,7 @@ internal static class ProcessCancellationExtensions
         {
             try
             {
-                await process.WaitForExitAsync(cancellationToken);
+                await process.WaitForExitSafeAsync(cancellationToken);
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Why

.NET's `Process.WaitForExitAsync()` blocks indefinitely on pipe EOF when redirected stdout/stderr pipes are held open by grandchild or unrelated processes ([dotnet/runtime#51277](https://github.com/dotnet/runtime/issues/51277)). This causes hangs in all 4 cancellation-layer call sites on v2.9.x.

PR [#394](https://github.com/alastairlundy/CliInvoke/pull/394) fixed this on main (v3). This PR backports the fix to v2.9.x, adapted for the divergent file structure.

## What changed

**`WaitForExitSafeAsync`** -- added to `ProcessWrapper.cs`. Polls `HasExited` via `Task.Delay(200)` instead of using `Process.WaitForExitAsync()` which blocks on stream EOF. Same approach as PR 394, placed at `src/CliInvoke/Helpers/ProcessWrapper.cs` (v2.9.x path).

**4 call sites updated** to use `WaitForExitSafeAsync`:
- `GracefulCancellation.cs` (2 sites)
- `ForcefulCancellation.cs` (1 site)
- `ProcessCancellationExtensions.cs` (1 site)

**`ProcessWrapper.Start()` race fix** -- moved `Id` capture before `Started` event and wrapped `base.ProcessName` in try-catch with fallback to `StartInfo.FileName`. Fixes a pre-existing net8.0 failure where `timeout` on Windows exits immediately with redirected stdout.

## Validation

- Build succeeds across all 4 TFMs (netstandard2.0, net8.0, net9.0, net10.0)
- 246/246 tests pass (was 244/246 before this change)

## References

- Upstream fix: PR [#394](https://github.com/alastairlundy/CliInvoke/pull/394)
- Root cause: [dotnet/runtime#51277](https://github.com/dotnet/runtime/issues/51277)

---

*Co-authored-by: GitHub Copilot App (using MiMo V2.5)*