### PR TITLE
fix: correct ProcessorAffinity upper bound validation (v2.10.x)

### DIFF
--- a/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
+++ b/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
@@ -58,7 +58,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
             ArgumentOutOfRangeException.ThrowIfLessThan((nint)processorAffinity, 0x0001);
             
             ArgumentOutOfRangeException.ThrowIfGreaterThan((nint)processorAffinity,
-                (1 << Environment.ProcessorCount) - 1);
+                ((nint)1 << Environment.ProcessorCount) - 1);
         }
 
         if (maxWorkingSet is not null)
@@ -70,7 +70,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
 #if NETSTANDARD2_0
                             (nint)
 #endif
-                            (1 << Environment.ProcessorCount) - 1;
+                            ((nint)1 << Environment.ProcessorCount) - 1;
 
         PriorityClass = priorityClass;
         EnablePriorityBoost = enablePriorityBoost;
@@ -125,7 +125,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
 #if NETSTANDARD2_0
         (nint)
 #endif
-        (1 << Environment.ProcessorCount) - 1
+        ((nint)1 << Environment.ProcessorCount) - 1
     );
 
     /// <summary>

--- a/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
+++ b/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
@@ -17,6 +17,24 @@ namespace CliInvoke.Core;
 public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
 {
     /// <summary>
+    /// Computes the maximum valid processor-affinity bitmask for the current system,
+    /// handling processor counts that equal or exceed the native integer bit width.
+    /// </summary>
+    /// <returns>The maximum processor-affinity mask.</returns>
+    public static nint ComputeMaxProcessorAffinity()
+    {
+        int processorCount = Environment.ProcessorCount;
+        int nativeWidth = IntPtr.Size * 8;
+
+        if (processorCount >= nativeWidth)
+        {
+            return (nint)IntPtr.MaxValue;
+        }
+
+        return ((nint)1 << processorCount) - 1;
+    }
+
+    /// <summary>
     /// Instantiates the <see cref="ProcessResourcePolicy"/> with default values unless specified parameters are provided.
     /// </summary>
     /// <param name="processorAffinity">The processor affinity to be used for the Process.</param>
@@ -58,7 +76,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
             ArgumentOutOfRangeException.ThrowIfLessThan((nint)processorAffinity, 0x0001);
             
             ArgumentOutOfRangeException.ThrowIfGreaterThan((nint)processorAffinity,
-                ((nint)1 << Environment.ProcessorCount) - 1);
+                ComputeMaxProcessorAffinity());
         }
 
         if (maxWorkingSet is not null)
@@ -67,10 +85,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
         
         ProcessorAffinity = processorAffinity ??
 #pragma warning restore CA1416
-#if NETSTANDARD2_0
-                            (nint)
-#endif
-                            ((nint)1 << Environment.ProcessorCount) - 1;
+                            ComputeMaxProcessorAffinity();
 
         PriorityClass = priorityClass;
         EnablePriorityBoost = enablePriorityBoost;
@@ -122,10 +137,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
     /// Creates a ProcessResourcePolicy with a default configuration.
     /// </summary>
     public static ProcessResourcePolicy Default { get; } = new(
-#if NETSTANDARD2_0
-        (nint)
-#endif
-        ((nint)1 << Environment.ProcessorCount) - 1
+        ComputeMaxProcessorAffinity()
     );
 
     /// <summary>

--- a/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
+++ b/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
@@ -58,7 +58,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
             ArgumentOutOfRangeException.ThrowIfLessThan((nint)processorAffinity, 0x0001);
             
             ArgumentOutOfRangeException.ThrowIfGreaterThan((nint)processorAffinity,
-                (nint)2 * Environment.ProcessorCount);
+                (1 << Environment.ProcessorCount) - 1);
         }
 
         if (maxWorkingSet is not null)
@@ -70,7 +70,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
 #if NETSTANDARD2_0
                             (nint)
 #endif
-                            2 * Environment.ProcessorCount - 1;
+                            (1 << Environment.ProcessorCount) - 1;
 
         PriorityClass = priorityClass;
         EnablePriorityBoost = enablePriorityBoost;
@@ -125,7 +125,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
 #if NETSTANDARD2_0
         (nint)
 #endif
-        2 * Environment.ProcessorCount - 1
+        (1 << Environment.ProcessorCount) - 1
     );
 
     /// <summary>

--- a/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
+++ b/src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs
@@ -28,7 +28,7 @@ public class ProcessResourcePolicy : IEquatable<ProcessResourcePolicy>
 
         if (processorCount >= nativeWidth)
         {
-            return (nint)IntPtr.MaxValue;
+            return (nint)(((long)1 << (nativeWidth - 1)) - 1);
         }
 
         return ((nint)1 << processorCount) - 1;

--- a/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
@@ -47,7 +47,7 @@ public class ProcessResourcePolicyBuilder : IProcessResourcePolicyBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(processorAffinity, 0x0001);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(processorAffinity,
-            (1 << Environment.ProcessorCount) - 1);
+            ((nint)1 << Environment.ProcessorCount) - 1);
         
         return new ProcessResourcePolicyBuilder(
             new ProcessResourcePolicy(

--- a/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
@@ -47,7 +47,7 @@ public class ProcessResourcePolicyBuilder : IProcessResourcePolicyBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(processorAffinity, 0x0001);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(processorAffinity,
-            ((nint)1 << Environment.ProcessorCount) - 1);
+            ProcessResourcePolicy.ComputeMaxProcessorAffinity());
         
         return new ProcessResourcePolicyBuilder(
             new ProcessResourcePolicy(

--- a/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
+++ b/src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs
@@ -39,7 +39,7 @@ public class ProcessResourcePolicyBuilder : IProcessResourcePolicyBuilder
     /// <param name="processorAffinity">The processor affinity to be used.</param>
     /// <returns>The newly created ProcessResourcePolicyBuilder with the updated ProcessorAffinity.</returns>
     /// <remarks>Process objects only support Processor Affinity on Windows and Linux operating systems.</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if processor affinity is less than 1 or greater than 2x Processor Count.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if processor affinity is less than 1 or greater than (1 << Processor Count) - 1.</exception>
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [Pure]
@@ -47,7 +47,7 @@ public class ProcessResourcePolicyBuilder : IProcessResourcePolicyBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(processorAffinity, 0x0001);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(processorAffinity,
-            2 * Environment.ProcessorCount);
+            (1 << Environment.ProcessorCount) - 1);
         
         return new ProcessResourcePolicyBuilder(
             new ProcessResourcePolicy(

--- a/tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs
+++ b/tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs
@@ -11,8 +11,8 @@ public class ProcessResourcePolicyBuilderTests
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [Theory]
-    [InlineData(1 * 16 - 1)]
-    [InlineData(1 * 8 - 1)]
+    [InlineData(0x000F)]  // 0b1111 - valid for 4+ processor systems
+    [InlineData(0x0007)]  // 0b0111 - valid for 3+ processor systems
     public void WithProcessorAffinity_ValidProcessorAffinity_Valid_Success(nint processorAffinity)
     {
         // Arrange
@@ -31,7 +31,7 @@ public class ProcessResourcePolicyBuilderTests
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [Theory]
-    [InlineData(2 * 24)]
+    [InlineData(0x10000)]  // 0b10000000000000000 - exceeds max for most systems
     [InlineData(0)]
     public void WithProcessorAffinity_ValidProcessorAffinity_Invalid_Fail(nint processorAffinity)
     {
@@ -174,10 +174,10 @@ public class ProcessResourcePolicyBuilderTests
     [SupportedOSPlatform("freebsd")]
     [SupportedOSPlatform("linux")]
     [Theory]
-    [InlineData(2 * 16 - 1,1024_000, 8192, true, ProcessPriorityClass.AboveNormal)]
-    [InlineData(1 * 16 -1, 8192, 1024, false, ProcessPriorityClass.Normal)]
-    [InlineData(1 * 8 - 1, 1024, 0, false,  ProcessPriorityClass.Normal)]
-    [InlineData(2 * 8 - 1, 1024, 1024, true,   ProcessPriorityClass.BelowNormal)]
+    [InlineData(0x000F, 1024_000, 8192, true, ProcessPriorityClass.AboveNormal)]   // 0b1111
+    [InlineData(0x0007, 8192, 1024, false, ProcessPriorityClass.Normal)]           // 0b0111
+    [InlineData(0x0003, 1024, 0, false, ProcessPriorityClass.Normal)]              // 0b0011
+    [InlineData(0x000F, 1024, 1024, true, ProcessPriorityClass.BelowNormal)]       // 0b1111
     public void Build_Successfully(nint processorAffinity, nint maxWorkingSet, nint minWorkingSet,
         bool priorityBoostEnabled, ProcessPriorityClass priorityClass)
     {

--- a/tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs
+++ b/tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs
@@ -17,7 +17,7 @@ public class ProcessResourcePolicyBuilderTests
 
         if (processorCount >= nativeWidth)
         {
-            return nint.MaxValue;
+            return (nint)(((long)1 << (nativeWidth - 1)) - 1);
         }
 
         return ((nint)1 << processorCount) - 1;

--- a/tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs
+++ b/tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Runtime.Versioning;
 using Assert = Xunit.Assert;
 
@@ -8,11 +10,55 @@ namespace CliInvoke.Tests.Builders;
 
 public class ProcessResourcePolicyBuilderTests
 {
+    private static nint ComputeMaxAffinity()
+    {
+        int processorCount = Environment.ProcessorCount;
+        int nativeWidth = IntPtr.Size * 8;
+
+        if (processorCount >= nativeWidth)
+        {
+            return nint.MaxValue;
+        }
+
+        return ((nint)1 << processorCount) - 1;
+    }
+
+    public static IEnumerable<object[]> ValidProcessorAffinityValues()
+    {
+        nint maxAffinity = ComputeMaxAffinity();
+        nint smallMask1 = (nint)0x0001;
+        nint smallMask2 = (nint)0x0003;
+        nint smallMask4 = (nint)0x000F;
+
+        if (smallMask4 <= maxAffinity)
+        {
+            yield return new object[] { smallMask4 };
+        }
+
+        if (smallMask2 <= maxAffinity && smallMask2 != smallMask4)
+        {
+            yield return new object[] { smallMask2 };
+        }
+
+        if (smallMask1 <= maxAffinity && smallMask1 != smallMask2 && smallMask1 != smallMask4)
+        {
+            yield return new object[] { smallMask1 };
+        }
+
+        yield return new object[] { maxAffinity };
+    }
+
+    public static IEnumerable<object[]> InvalidProcessorAffinityValues()
+    {
+        nint maxAffinity = ComputeMaxAffinity();
+        yield return new object[] { maxAffinity + 1 };
+        yield return new object[] { (nint)0 };
+    }
+
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [Theory]
-    [InlineData(0x000F)]  // 0b1111 - valid for 4+ processor systems
-    [InlineData(0x0007)]  // 0b0111 - valid for 3+ processor systems
+    [MemberData(nameof(ValidProcessorAffinityValues))]
     public void WithProcessorAffinity_ValidProcessorAffinity_Valid_Success(nint processorAffinity)
     {
         // Arrange
@@ -31,8 +77,7 @@ public class ProcessResourcePolicyBuilderTests
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [Theory]
-    [InlineData(0x10000)]  // 0b10000000000000000 - exceeds max for most systems
-    [InlineData(0)]
+    [MemberData(nameof(InvalidProcessorAffinityValues))]
     public void WithProcessorAffinity_ValidProcessorAffinity_Invalid_Fail(nint processorAffinity)
     {
         // Arrange
@@ -169,15 +214,31 @@ public class ProcessResourcePolicyBuilderTests
                 .SetMinWorkingSet(minWorkingSet).SetMaxWorkingSet(maxWorkingSet));
     }
 
+    public static IEnumerable<object[]> BuildSuccessData()
+    {
+        nint maxAffinity = ComputeMaxAffinity();
+        nint mask4 = (nint)0x000F;
+        nint mask3 = (nint)0x0003;
+
+        if (mask4 <= maxAffinity)
+        {
+            yield return new object[] { maxAffinity, 1024_000, 8192, true, ProcessPriorityClass.AboveNormal };
+            yield return new object[] { mask4, 8192, 1024, false, ProcessPriorityClass.Normal };
+        }
+
+        if (mask3 <= maxAffinity)
+        {
+            yield return new object[] { mask3, 1024, 0, false, ProcessPriorityClass.Normal };
+            yield return new object[] { maxAffinity & ~mask3, 1024, 1024, true, ProcessPriorityClass.BelowNormal };
+        }
+    }
+
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("macos")]
     [SupportedOSPlatform("freebsd")]
     [SupportedOSPlatform("linux")]
     [Theory]
-    [InlineData(0x000F, 1024_000, 8192, true, ProcessPriorityClass.AboveNormal)]   // 0b1111
-    [InlineData(0x0007, 8192, 1024, false, ProcessPriorityClass.Normal)]           // 0b0111
-    [InlineData(0x0003, 1024, 0, false, ProcessPriorityClass.Normal)]              // 0b0011
-    [InlineData(0x000F, 1024, 1024, true, ProcessPriorityClass.BelowNormal)]       // 0b1111
+    [MemberData(nameof(BuildSuccessData))]
     public void Build_Successfully(nint processorAffinity, nint maxWorkingSet, nint minWorkingSet,
         bool priorityBoostEnabled, ProcessPriorityClass priorityClass)
     {


### PR DESCRIPTION
## What changed

Fixed `ProcessorAffinity` upper bound validation in `ProcessResourcePolicy` and `ProcessResourcePolicyBuilder`. The bitmask validation now uses the correct formula `(1 << Environment.ProcessorCount) - 1` instead of the incorrect `2 * Environment.ProcessorCount`.

Files modified:
- `src/CliInvoke.Core/Primitives/Policies/ProcessResourcePolicy.cs`
- `src/CliInvoke/Builders/ProcessResourcePolicyBuilder.cs`
- `tests/CliInvoke.Tests/Builders/ProcessResourcePolicyBuilderTests.cs`

## Why it was changed

The old bound rejected valid bitmasks. On a 4-processor host, mask `0b1001` (9) was rejected because the bound was 8, but the correct maximum is 15.

## Testing

- [x] `dotnet test` passes locally on the supported TFMs
- [ ] New or updated tests are included for the change
- [x] Behavior-affecting changes are covered by tests

## Documentation

- [ ] README, docs/, or XML doc comments updated (if applicable)
- [ ] VERSION_HISTORY.md updated (if user-visible)
- [x] No docs change needed

## Contribution Policy compliance

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [x] My branch is up to date with `main` and the diff is focused
- [x] Commit messages are clear and describe the change
- [x] I have not introduced secrets, credentials, or copyrighted content
- [x] For changes that affect resource-owning types, I followed the disposal conventions in the README

## Authorship

- [x] This PR was Co-Authored by AI (the human author reviewed, edited, and takes responsibility for the final code; commits include the appropriate `Co-authored-by:` trailer(s))

- **AI agent used:** GitHub Copilot CLI
- **AI model used:** mimo-v2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected processor-affinity validation and defaults to accurately support one bit per available processor.
  * Updated processor-affinity limits and policy handling for more reliable process resource configuration.

* **Tests**
  * Expanded coverage using explicit processor-affinity bitmasks across supported policy combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->