### PR TITLE
Fix ProcessConfiguration.Equals and RunnerProcessFactory admin config bugs

### DIFF
--- a/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
+++ b/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
@@ -330,7 +330,8 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
                && WorkingDirectoryPath.Equals(other.WorkingDirectoryPath)
                && UseShellExecution.Equals(other.UseShellExecution)
                && Credential.Equals(other.Credential)
-               && ResourcePolicy.Equals(other.ResourcePolicy)
+               && RequiresAdministrator == other.RequiresAdministrator
+               && WindowCreation == other.WindowCreation
                && StandardInput.Equals(other.StandardInput)
 #pragma warning disable CS0618 // Type or member is obsolete
                && StandardOutput.Equals(other.StandardOutput)
@@ -386,6 +387,8 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
         hashCode.Add(StandardError);
 #pragma warning restore CS0618 // Type or member is obsolete
         hashCode.Add(ResourcePolicy);
+        hashCode.Add(RequiresAdministrator);
+        hashCode.Add(WindowCreation);
         hashCode.Add(StandardInputEncoding);
         hashCode.Add(StandardOutputEncoding);
         hashCode.Add(StandardErrorEncoding);

--- a/src/CliInvoke/Extensibility/Factories/RunnerProcessFactory.cs
+++ b/src/CliInvoke/Extensibility/Factories/RunnerProcessFactory.cs
@@ -68,9 +68,7 @@ public class RunnerProcessFactory : IRunnerProcessFactory
             .ConfigureWindowCreation(processConfigToBeRun.WindowCreation);
 
         if (runnerProcessConfig.RequiresAdministrator)
-            commandBuilder = new ProcessConfigurationBuilder(
-                runnerProcessConfig.TargetFilePath
-            ).RequireAdministratorPrivileges();
+            commandBuilder = commandBuilder.RequireAdministratorPrivileges();
 
         return commandBuilder.Build();
     }

--- a/tests/CliInvoke.Tests/Factories/RunnerProcessFactoryTests.cs
+++ b/tests/CliInvoke.Tests/Factories/RunnerProcessFactoryTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using CliInvoke.Core.Extensibility.Factories;
+using CliInvoke.Extensibility.Factories;
+using Assert = Xunit.Assert;
+
+namespace CliInvoke.Tests.Factories;
+
+public class RunnerProcessFactoryTests
+{
+    [Fact]
+    public void CreateRunnerConfiguration_RequiresAdministrator_PreservesAdminFlag()
+    {
+        // Arrange
+        IRunnerProcessFactory factory = new RunnerProcessFactory();
+
+        ProcessConfiguration processConfigToBeRun = new ProcessConfigurationBuilder("target.exe")
+            .SetArguments("--input value")
+            .Build();
+
+        ProcessConfiguration runnerProcessConfig = new ProcessConfigurationBuilder("runner.exe")
+            .RequireAdministratorPrivileges()
+            .Build();
+
+        // Act
+        ProcessConfiguration result = factory.CreateRunnerConfiguration(processConfigToBeRun, runnerProcessConfig);
+
+        // Assert
+        Assert.True(result.RequiresAdministrator);
+    }
+
+    [Fact]
+    public void CreateRunnerConfiguration_RequiresAdministrator_PreservesOtherSettings()
+    {
+        // Arrange
+        IRunnerProcessFactory factory = new RunnerProcessFactory();
+
+        var envVars = new Dictionary<string, string> { { "MY_VAR", "hello" } };
+
+        ProcessConfiguration processConfigToBeRun = new ProcessConfigurationBuilder("target.exe")
+            .SetArguments("--input value")
+            .SetEnvironmentVariables(envVars)
+            .SetStandardInputEncoding(System.Text.Encoding.UTF8)
+            .Build();
+
+        ProcessConfiguration runnerProcessConfig = new ProcessConfigurationBuilder("runner.exe")
+            .RequireAdministratorPrivileges()
+            .Build();
+
+        // Act
+        ProcessConfiguration result = factory.CreateRunnerConfiguration(processConfigToBeRun, runnerProcessConfig);
+
+        // Assert
+        Assert.True(result.RequiresAdministrator);
+        Assert.Contains("--input value", result.Arguments);
+        Assert.Equal(envVars, result.EnvironmentVariables);
+        Assert.Equal(System.Text.Encoding.UTF8, result.StandardInputEncoding);
+    }
+
+    [Fact]
+    public void CreateRunnerConfiguration_NoAdmin_DoesNotSetAdminFlag()
+    {
+        // Arrange
+        IRunnerProcessFactory factory = new RunnerProcessFactory();
+
+        ProcessConfiguration processConfigToBeRun = new ProcessConfigurationBuilder("target.exe")
+            .SetArguments("--flag")
+            .Build();
+
+        ProcessConfiguration runnerProcessConfig = new ProcessConfigurationBuilder("runner.exe")
+            .Build();
+
+        // Act
+        ProcessConfiguration result = factory.CreateRunnerConfiguration(processConfigToBeRun, runnerProcessConfig);
+
+        // Assert
+        Assert.False(result.RequiresAdministrator);
+    }
+}


### PR DESCRIPTION
## What changed

- **`src/CliInvoke.Core/Primitives/ProcessConfiguration.cs`** (`Equals` and `GetHashCode`): Removed duplicate `ResourcePolicy` comparison. Added missing `RequiresAdministrator` and `WindowCreation` comparisons to `Equals`. Added both properties to `GetHashCode` for consistency.
- **`src/CliInvoke/Extensibility/Factories/RunnerProcessFactory.cs`** (`CreateRunnerConfiguration`): When `RequiresAdministrator` is true, now chains `RequireAdministratorPrivileges()` on the existing builder instead of replacing it with a fresh one.

## Why it was changed

Two correctness bugs found during the architecture review (2026-08-19) that affect the v2.10.x branch:

**B2** - `ProcessConfiguration.Equals` compared `ResourcePolicy` twice and never compared `RequiresAdministrator` or `WindowCreation`. Two configurations differing only in admin requirement or window creation were considered equal, breaking any equality-based logic (caching, deduplication, test assertions, dictionary keys).

**B3** - `RunnerProcessFactory.CreateRunnerConfiguration` discarded all accumulated configuration (arguments, environment variables, resource policy, encodings, pipes, credentials, shell execution, window creation) when `RequiresAdministrator` was set, replacing the builder with a fresh one that only had `RequireAdministratorPrivileges()`.

## Testing

- [x] `dotnet test` passes locally on the supported TFMs (net8.0, net9.0, net10.0 - all 246 tests pass)
- [ ] New or updated tests are included for the change
- [ ] Behavior-affecting changes are covered by tests

## Documentation

- [ ] README, docs/, or XML doc comments updated (if applicable)
- [ ] VERSION_HISTORY.md updated (if user-visible)
- [x] No docs change needed

## Contribution Policy compliance

<!-- Confirm you have read and followed CONTRIBUTING.md (https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md). -->

- [ ] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [ ] My branch is up to date with `main` and the diff is focused
- [ ] Commit messages are clear and describe the change
- [ ] I have not introduced secrets, credentials, or copyrighted content
- [ ] For changes that affect resource-owning types, I followed the disposal conventions in the README

## Authorship

- [x] This PR was Co-Authored by AI (the human author reviewed, edited, and takes responsibility for the final code; commits include the appropriate `Co-authored-by:` trailer(s))

If this PR was Co-Authored by AI, please also fill in the following:

- **AI agent used:** GitHub Copilot CLI
- **AI model used:** mimo-v2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Administrator privilege and window settings are now correctly included when comparing process configurations.
  * Process configuration options are preserved when enabling administrator privileges, preventing previously selected settings from being lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->