### PR TITLE
fix: correct ProcessConfiguration.Equals and RunnerProcessFactory admin config handling

### DIFF
--- a/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
+++ b/src/CliInvoke.Core/Primitives/ProcessConfiguration.cs
@@ -333,7 +333,8 @@ public class ProcessConfiguration : IEquatable<ProcessConfiguration>, IDisposabl
                && WorkingDirectoryPath.Equals(other.WorkingDirectoryPath)
                && UseShellExecution.Equals(other.UseShellExecution)
                && Credential.Equals(other.Credential)
-               && ResourcePolicy.Equals(other.ResourcePolicy)
+               && RequiresAdministrator.Equals(other.RequiresAdministrator)
+               && WindowCreation.Equals(other.WindowCreation)
                && StandardInput.Equals(other.StandardInput)
 #pragma warning disable CS0618 // Type or member is obsolete
                && StandardOutput.Equals(other.StandardOutput)

--- a/src/CliInvoke/Extensibility/Factories/RunnerProcessFactory.cs
+++ b/src/CliInvoke/Extensibility/Factories/RunnerProcessFactory.cs
@@ -68,9 +68,7 @@ public class RunnerProcessFactory : IRunnerProcessFactory
             .ConfigureWindowCreation(processConfigToBeRun.WindowCreation);
 
         if (runnerProcessConfig.RequiresAdministrator)
-            commandBuilder = new ProcessConfigurationBuilder(
-                runnerProcessConfig.TargetFilePath
-            ).RequireAdministratorPrivileges();
+            commandBuilder = commandBuilder.RequireAdministratorPrivileges();
 
         return commandBuilder.Build();
     }


### PR DESCRIPTION
## What changed

- **`ProcessConfiguration.Equals`**: Removed duplicate `ResourcePolicy` comparison; added missing `RequiresAdministrator` and `WindowCreation` comparisons.
- **`RunnerProcessFactory.CreateRunnerConfiguration`**: Chain `RequireAdministratorPrivileges()` onto the existing builder instead of replacing it, which silently discarded all configured settings.

## Why it was changed

Both are correctness bugs (B2, B3) found during architecture review. The `Equals` bug makes configurations differing only in admin/window settings appear equal. The factory bug drops all command settings when admin privileges are requested.

## Testing

- [x] `dotnet test` passes locally on the supported TFMs
- [ ] New or updated tests are included for the change

## Documentation

- [x] No docs change needed

## Contribution Policy compliance

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [x] My branch is up to date and the diff is focused
- [x] Commit messages are clear and describe the change
- [x] I have not introduced secrets, credentials, or copyrighted content

## Authorship

- [x] This PR was Co-Authored by AI (the human author reviewed, edited, and takes responsibility for the final code; commits include the appropriate `Co-authored-by:` trailer(s))

- **AI agent used:** GitHub Copilot CLI
- **AI model used:** mimo-v2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Process configurations now correctly recognize administrator privileges and window settings when determining equality.
  - Existing process settings are preserved when administrator privileges are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->