### PR TITLE
Add agent skills (targeting the CliInvoke 3.0 API)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,5 +1,7 @@
 # CliInvoke AI Agent Skills
 
+> **API version note:** These skills describe the **upcoming CliInvoke 3.0 configuration API** — the `*Spec` configuration seams (e.g. `ArgumentsSpec`, `EnvironmentVariablesSpec`, `ProcessResourcePolicySpec`, `UserCredentialSpec`) and the `ConfigureXxx(Action<XxxSpec>)` builder methods. This API is **not yet in a released package**. On the current released (2.x) API the equivalent surface is the builder types (`IArgumentsBuilder`, `UserCredentialBuilder`, etc.). Agents running against a 2.x package should treat the builder API as the live surface and expect the spec API in 3.0.
+
 This directory contains SKILLs designed to guide AI agents in correctly using the CliInvoke library.
 
 ## Organization

--- a/skills/cliinvoke-core/generate-process-configuration/SKILL.md
+++ b/skills/cliinvoke-core/generate-process-configuration/SKILL.md
@@ -2,6 +2,7 @@
 name: generate-process-configuration
 description: Guidance on correctly utilizing IProcessConfigurationBuilder to create ProcessConfiguration objects, ensuring proper build and redirection setup. USE FOR guidelines on utilizing IProcessConfigurationBuilder to create ProcessConfiguration objects, including build and redirection setup. DO NOT USE FOR executing the resulting configuration.
 compatibility: Requires one or more CliInvoke NuGet packages (such as CliInvoke.Core, CliInvoke, or CliInvoke.Specialization)
+targets: CliInvoke 3.0 (spec API — see skills/README.md for version note)
 ---
 # Generate Process Configuration
 

--- a/skills/cliinvoke-core/implement-resource-lifecycle/SKILL.md
+++ b/skills/cliinvoke-core/implement-resource-lifecycle/SKILL.md
@@ -2,11 +2,12 @@
 name: implement-resource-lifecycle
 description: Guidance on auditing and managing the lifecycle of disposable types in CliInvoke to prevent resource leaks and secure sensitive data. USE FOR auditing and managing disposable types (ProcessConfiguration, IExternalProcess, etc.) to prevent resource leaks. DO NOT USE FOR general C# memory management.
 compatibility: Requires one or more CliInvoke NuGet packages (such as CliInvoke.Core, CliInvoke, or CliInvoke.Specialization)
+targets: CliInvoke 3.0 (spec API — see skills/README.md for version note)
 ---
 # Implement Resource Lifecycle
 
 ## When to Use
-- When auditing code for proper disposal of CliInvoke's six mandatory disposable types: `ProcessConfiguration`, `IExternalProcess`, `PipedProcessResult`, `UserCredential`, `UserCredentialSpec`, and `UserCredentialBuilder`.
+- When auditing code for proper disposal of CliInvoke's mandatory disposable types: `ProcessConfiguration`, `IExternalProcess`, `PipedProcessResult`, `UserCredential`, and the credential-build type for your version — `UserCredentialBuilder` on 2.x or `UserCredentialSpec` on 3.0.
 - When deciding between `using` and `await using` in async methods.
 - When investigating a suspected handle leak, memory pressure, or `SecureString` retention issue.
 - When the user asks about `SecureString` cleanup or process/stream lifetime in CliInvoke.
@@ -22,7 +23,7 @@ If you configure `ProcessInvoker` with middleware (`UseLogging`, `UsePostExitVal
 
 ## Mandatory Disposable Types
 
-The following six types MUST be disposed of. Failure to do so can lead to handle leaks, memory pressure, or sensitive data remaining in memory.
+The following types MUST be disposed of (five on the 2.x API, six once `UserCredentialSpec` ships in 3.0). Failure to do so can lead to handle leaks, memory pressure, or sensitive data remaining in memory.
 
 ### 1. `ProcessConfiguration`
 - **Reason**: Manages `StandardInput` (StreamWriter) and potentially a `SecureString` credential.
@@ -48,11 +49,11 @@ The following six types MUST be disposed of. Failure to do so can lead to handle
 - **Note**: If assigned to a `ProcessConfiguration`, the configuration's disposal will also dispose the credential.
 - **Example**: See [UserCredential.md](./references/UserCredential.md)
 
-### 5. `UserCredentialSpec`
+### 5. `UserCredentialSpec` (CliInvoke 3.0)
 - **Reason**: A sealed configuration seam that holds a `SecureString` for passwords during credential construction. Implements `IDisposable` to clear the secure string from memory.
 - **Pattern**: Always wrap the spec in a `using` block.
 - **Timing**: Dispose immediately after calling `.Build()`.
-- **Note**: `UserCredentialSpec` is the recommended replacement for `UserCredentialBuilder`. Prefer it in new code.
+- **Note**: This is the **3.0** replacement for the 2.x `UserCredentialBuilder`. Prefer it in new code **once you are on CliInvoke 3.0** (see the version note in `skills/README.md`).
 - **Example**:
   ```csharp
   UserCredential credential;
@@ -64,18 +65,18 @@ The following six types MUST be disposed of. Failure to do so can lead to handle
   // spec disposed here; SecureString cleared from memory
   ```
 
-### 6. `UserCredentialBuilder`
+### 6. `UserCredentialBuilder` (CliInvoke 2.x — current released API)
 - **Reason**: Holds a `SecureString` during the construction of credentials.
 - **Pattern**: Always wrap the builder in a `using` block.
 - **Timing**: Dispose immediately after calling `.Build()`.
-- **Note**: Deprecated in favour of `UserCredentialSpec`. Use `UserCredentialSpec` for new code.
+- **Note**: This is the **current released (2.x)** type. It is superseded by `UserCredentialSpec` in 3.0; use `UserCredentialSpec` once you move to 3.0.
 - **Example**: See [UserCredentialBuilder.md](./references/UserCredentialBuilder.md)
 
 ## Implementation Checklist
 
 - [ ] Every instance of the 6 types above is wrapped in a `using` or `await using` block.
 - [ ] `IExternalProcess` and `PipedProcessResult` use `await using` in async methods.
-- [ ] `UserCredentialSpec` (or `UserCredentialBuilder`) is disposed of after `.Build()` is called.
+- [ ] The credential-build type is disposed of after `.Build()` is called — `UserCredentialSpec` on 3.0, `UserCredentialBuilder` on 2.x.
 - [ ] `ProcessConfiguration` is disposed of after the process has completed and results are processed.
 
 For detailed usage examples, see the following references:

--- a/skills/cliinvoke-core/implement-resource-lifecycle/references/UserCredentialBuilder.md
+++ b/skills/cliinvoke-core/implement-resource-lifecycle/references/UserCredentialBuilder.md
@@ -1,4 +1,6 @@
-# UserCredentialBuilder Disposal
+# UserCredentialBuilder Disposal (CliInvoke 2.x — current released API)
+
+> On **CliInvoke 3.0** use `UserCredentialSpec` instead (see the `UserCredentialSpec` section in the skill body). This page documents the current 2.x builder API.
 
 `UserCredentialBuilder` holds a `SecureString` sensitive password while building a credential.
 


### PR DESCRIPTION
## What changed

Adds the `skills/` directory (AI-agent SKILLs + eval task packs) to the repo on a clean `main` baseline. These were extracted from the `skills` branch but **only** the `skills/` tree — the `src/` config-seam refactor, the stale `tickets/`, and the `docs/decisions/` ADR were intentionally **not** included, so this branch is independent of the unreleased 3.0 `src/` work.

Two follow-up consistency edits were made on top of the copied tree:
- `skills/README.md`: added a version note stating the skills target the **upcoming CliInvoke 3.0 spec API** (not yet released), with the 2.x builder equivalents noted. A `targets:` line was added to the two spec-describing skills (`generate-process-configuration`, `implement-resource-lifecycle`).
- `skills/cliinvoke-core/implement-resource-lifecycle/`: `UserCredentialBuilder` is now framed as the **current 2.x** type (no longer labelled "deprecated"), `UserCredentialSpec` as the **3.0** replacement; intro, checklist, and `references/UserCredentialBuilder.md` updated to reflect the version split.

All 5 eval packs were reviewed and found API-neutral and consistent across 2.x and 3.0 — no changes required.

## Why it was changed

I want the agent skills shipped to `main`, but they describe the **upcoming CliInvoke 3.0 configuration API** (`*Spec` seams, `ConfigureXxx(Action<XxxSpec>)`) that isn't officially released yet. To keep them useful and non-misleading on the current stable 2.x release, the version scope is made explicit and the credential API section is reconciled so agents on the released package aren't steered to non-existent APIs.

## Testing

This is a documentation-only change (Markdown + YAML). No compiled code, so `dotnet test` is unaffected and no new tests are required.

- [x] `dotnet test` passes locally on the supported TFMs (unaffected — no code changed)
- [x] New or updated tests are included for the change (N/A — no code change)
- [x] Behavior-affecting changes are covered by tests (N/A — no behavior change)

## Documentation

- [x] README, docs/, or XML doc comments updated (if applicable) — `skills/README.md` carries the 3.0-vs-2.x API scope note.
- [ ] VERSION_HISTORY.md updated (if user-visible) — N/A; no package/version change.
- [x] No docs change needed (beyond the skills themselves)

## Contribution Policy compliance

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [x] My branch is up to date with `main` and the diff is focused — branch is cut from `origin/main` and contains only `skills/` files.
- [x] Commit messages are clear and describe the change
- [x] I have not introduced secrets, credentials, or copyrighted content
- [x] For changes that affect resource-owning types, I followed the disposal conventions in the README (N/A — no code change; skills are documentation only)

## Authorship

- [ ] This PR was written entirely by a human (no AI assistance)
- [x] This PR was Co-Authored by AI (the human author reviewed, edited, and takes responsibility for the final code; commits include the appropriate `Co-authored-by:` trailer(s))

If this PR was Co-Authored by AI, please also fill in the following:

- **AI agent used:** GitHub Copilot CLI
- **AI model used:** hy3 (model ID: hy3)