### PR TITLE
Add ``Canceled`` and ``Signal`` to ``ProcessResult`` and derived types

### DIFF
--- a/src/CliInvoke.Core/Primitives/Results/BufferedProcessResult.cs
+++ b/src/CliInvoke.Core/Primitives/Results/BufferedProcessResult.cs
@@ -13,6 +13,9 @@
      See THIRD_PARTY_NOTICES.txt for a full copy of the MIT LICENSE.
  */
 
+using System;
+using System.Runtime.InteropServices;
+
 namespace CliInvoke.Core;
 
 /// <summary>
@@ -31,6 +34,13 @@ public class BufferedProcessResult : ProcessResult, IEquatable<BufferedProcessRe
     /// <param name="standardError">The process' standard error as a string.</param>
     /// <param name="startTime">The start time of the process.</param>
     /// <param name="exitTime">The exit time of the process.</param>
+    /// <param name="canceled">
+    ///     A value indicating whether the library terminated the process via its cancellation
+    ///     machinery rather than the process exiting on its own.
+    /// </param>
+    /// <param name="signal">
+    ///     The POSIX signal that terminated the process, or <c>null</c> when not applicable.
+    /// </param>
     public BufferedProcessResult(
         string executableFilePath,
         int exitCode,
@@ -38,8 +48,10 @@ public class BufferedProcessResult : ProcessResult, IEquatable<BufferedProcessRe
         string standardOutput,
         string standardError,
         DateTime startTime,
-        DateTime exitTime)
-        : base(executableFilePath, exitCode, processId, startTime, exitTime)
+        DateTime exitTime,
+        bool canceled,
+        PosixSignal? signal)
+        : base(executableFilePath, exitCode, processId, startTime, exitTime, canceled, signal)
     {
         ArgumentException.ThrowIfNullOrEmpty(executableFilePath);
         ArgumentNullException.ThrowIfNull(standardOutput);
@@ -77,12 +89,16 @@ public class BufferedProcessResult : ProcessResult, IEquatable<BufferedProcessRe
         if (other is null)
             return false;
 
+#pragma warning disable CA1416
         return ExecutedFilePath == other.ExecutedFilePath &&
                StandardOutput == other.StandardOutput
                && StandardError == other.StandardError
                && ExitCode == other.ExitCode &&
                StartTime == other.StartTime &&
-               ExitTime == other.ExitTime;
+               ExitTime == other.ExitTime &&
+               Canceled == other.Canceled &&
+               Signal == other.Signal;
+#pragma warning restore CA1416
     }
 
     /// <summary>
@@ -113,8 +129,10 @@ public class BufferedProcessResult : ProcessResult, IEquatable<BufferedProcessRe
     /// <returns>The hash code for the current BufferedProcessResult.</returns>
     public override int GetHashCode()
     {
+#pragma warning disable CA1416
         return HashCode.Combine(ExecutedFilePath, StandardOutput, StandardError, ExitCode,
-            StartTime, ExitTime);
+            StartTime, ExitTime, Canceled, Signal);
+#pragma warning restore CA1416
     }
 
     /// <summary>

--- a/src/CliInvoke.Core/Primitives/Results/PipedProcessResult.cs
+++ b/src/CliInvoke.Core/Primitives/Results/PipedProcessResult.cs
@@ -7,6 +7,9 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
    */
 
+using System;
+using System.Runtime.InteropServices;
+
 namespace CliInvoke.Core;
 
 /// <summary>
@@ -29,6 +32,13 @@ public class PipedProcessResult
     /// <param name="exitTime">The exit time of the process.</param>
     /// <param name="standardOutput">The process' standard output.</param>
     /// <param name="standardError">The process' standard error.</param>
+    /// <param name="canceled">
+    ///     A value indicating whether the library terminated the process via its cancellation
+    ///     machinery rather than the process exiting on its own.
+    /// </param>
+    /// <param name="signal">
+    ///     The POSIX signal that terminated the process, or <c>null</c> when not applicable.
+    /// </param>
     public PipedProcessResult(
         string executableFilePath,
         int exitCode,
@@ -36,9 +46,11 @@ public class PipedProcessResult
         DateTime startTime,
         DateTime exitTime,
         Stream standardOutput,
-        Stream standardError
+        Stream standardError,
+        bool canceled,
+        PosixSignal? signal
     )
-        : base(executableFilePath, exitCode, processId, startTime, exitTime)
+        : base(executableFilePath, exitCode, processId, startTime, exitTime, canceled, signal)
     {
         ArgumentException.ThrowIfNullOrEmpty(executableFilePath);
 
@@ -97,12 +109,16 @@ public class PipedProcessResult
         if (other is null)
             return false;
 
+#pragma warning disable CA1416
         return ExecutedFilePath == other.ExecutedFilePath &&
                StandardOutput.Equals(other.StandardOutput)
                && StandardError.Equals(other.StandardError)
                && ExitCode.Equals(other.ExitCode)
                && StartTime.Equals(other.StartTime)
-               && ExitTime.Equals(other.ExitTime);
+               && ExitTime.Equals(other.ExitTime)
+               && Canceled.Equals(other.Canceled)
+               && Signal.Equals(other.Signal);
+#pragma warning restore CA1416
     }
 
     /// <summary>
@@ -133,8 +149,10 @@ public class PipedProcessResult
     /// <returns>The hash code for the current PipedProcessResult.</returns>
     public override int GetHashCode()
     {
+#pragma warning disable CA1416
         return HashCode.Combine(ExecutedFilePath, ExitCode, StartTime, ExitTime, StandardOutput,
-            StandardError);
+            StandardError, Canceled, Signal);
+#pragma warning restore CA1416
     }
 
     /// <summary>

--- a/src/CliInvoke.Core/Primitives/Results/ProcessResult.cs
+++ b/src/CliInvoke.Core/Primitives/Results/ProcessResult.cs
@@ -96,9 +96,11 @@ public class ProcessResult : IEquatable<ProcessResult>
     /// <remarks>
     ///     This is a best-effort heuristic derived from <see cref="ExitCode" />
     ///     (an <c>ExitCode &gt; 128</c> is interpreted as termination by signal
-    ///     <c>ExitCode - 128</c>). It is not authoritative and is <c>null</c> on Windows.
+    ///     <c>ExitCode - 128</c>). It is not authoritative and is <c>null</c> on Windows,
+    ///     where no POSIX signal terminated the process. The property is intentionally
+    ///     supported on every platform so Windows-targeted consumers can read it (always
+    ///     <c>null</c>) without triggering CA1416.
     /// </remarks>
-    [UnsupportedOSPlatform("windows")]
     public PosixSignal? Signal { get; }
 
     /// <summary>

--- a/src/CliInvoke.Core/Primitives/Results/ProcessResult.cs
+++ b/src/CliInvoke.Core/Primitives/Results/ProcessResult.cs
@@ -13,6 +13,10 @@
      See THIRD_PARTY_NOTICES.txt for a full copy of the MIT LICENSE.
  */
 
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
 namespace CliInvoke.Core;
 
 /// <summary>
@@ -28,18 +32,31 @@ public class ProcessResult : IEquatable<ProcessResult>
     /// <param name="processId"></param>
     /// <param name="startTime">The start time of the process.</param>
     /// <param name="exitTime">The exit time of the process.</param>
+    /// <param name="canceled">
+    ///     A value indicating whether the library terminated the process via its cancellation
+    ///     machinery rather than the process exiting on its own.
+    /// </param>
+    /// <param name="signal">
+    ///     The POSIX signal that terminated the process, or <c>null</c> when not applicable.
+    /// </param>
     public ProcessResult(
         string executableFilePath,
         int exitCode,
         int processId,
         DateTime startTime,
-        DateTime exitTime)
+        DateTime exitTime,
+        bool canceled,
+        PosixSignal? signal)
     {
         ExitCode = exitCode;
         ExecutedFilePath = executableFilePath;
         StartTime = startTime;
         ExitTime = exitTime;
         ProcessId = processId;
+        Canceled = canceled;
+#pragma warning disable CA1416
+        Signal = signal;
+#pragma warning restore CA1416
     }
 
     /// <summary>
@@ -68,6 +85,23 @@ public class ProcessResult : IEquatable<ProcessResult>
     public DateTime ExitTime { get; }
 
     /// <summary>
+    ///     A value indicating whether the library terminated the process via its cancellation
+    ///     machinery, as opposed to the process exiting on its own.
+    /// </summary>
+    public bool Canceled { get; }
+
+    /// <summary>
+    ///     The POSIX signal that terminated the process, surfaced on Unix only.
+    /// </summary>
+    /// <remarks>
+    ///     This is a best-effort heuristic derived from <see cref="ExitCode" />
+    ///     (an <c>ExitCode &gt; 128</c> is interpreted as termination by signal
+    ///     <c>ExitCode - 128</c>). It is not authoritative and is <c>null</c> on Windows.
+    /// </remarks>
+    [UnsupportedOSPlatform("windows")]
+    public PosixSignal? Signal { get; }
+
+    /// <summary>
     ///     How long the Command took to execute represented as a TimeSpan.
     /// </summary>
     public TimeSpan RuntimeDuration => ExitTime.Subtract(StartTime);
@@ -89,11 +123,15 @@ public class ProcessResult : IEquatable<ProcessResult>
         if (other.GetType() != GetType())
             return false;
 
+#pragma warning disable CA1416
         return ExitCode == other.ExitCode
                && ExecutedFilePath == other.ExecutedFilePath
                && ProcessId == other.ProcessId
                && StartTime == other.StartTime
-               && ExitTime == other.ExitTime;
+               && ExitTime == other.ExitTime
+               && Canceled == other.Canceled
+               && Signal == other.Signal;
+#pragma warning restore CA1416
     }
 
     /// <summary>
@@ -121,7 +159,9 @@ public class ProcessResult : IEquatable<ProcessResult>
     /// <returns>The hash code for the current ProcessResult.</returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(ExitCode, ExecutedFilePath, StartTime, ExitTime);
+#pragma warning disable CA1416
+        return HashCode.Combine(ExitCode, ExecutedFilePath, ProcessId, StartTime, ExitTime, Canceled, Signal);
+#pragma warning restore CA1416
     }
 
     /// <summary>

--- a/src/CliInvoke/ProcessInvocationPipeline.cs
+++ b/src/CliInvoke/ProcessInvocationPipeline.cs
@@ -55,7 +55,6 @@ internal class ProcessInvocationPipeline
 
                 return (TResult)new ProcessResult(
                     externalProcess.Configuration.TargetFilePath,
-                    //TODO: Look into whether exit code 0 here is valid.
                     0,
                     processId,
                     DateTime.UtcNow,

--- a/src/CliInvoke/ProcessInvocationPipeline.cs
+++ b/src/CliInvoke/ProcessInvocationPipeline.cs
@@ -58,7 +58,9 @@ internal class ProcessInvocationPipeline
                     0,
                     processId,
                     DateTime.UtcNow,
-                    DateTime.UtcNow);
+                    DateTime.UtcNow,
+                    canceled: false,
+                    signal: null);
             }
 
             await externalProcess.StartAsync(ctx.CancellationToken);

--- a/src/CliInvoke/Processes/ExternalProcess.cs
+++ b/src/CliInvoke/Processes/ExternalProcess.cs
@@ -203,7 +203,9 @@ public sealed class ExternalProcess : ISuspendableExternalProcess, IExternalProc
             _processWrapper.ExitCode,
             _processWrapper.Id,
             _processWrapper.StartTime,
-            _processWrapper.ExitTime
+            _processWrapper.ExitTime,
+            canceled: _processWrapper.Canceled,
+            signal: _processWrapper.Signal
         );
 
         return result;
@@ -239,7 +241,9 @@ public sealed class ExternalProcess : ISuspendableExternalProcess, IExternalProc
                 _processWrapper.ExitCode,
                 _processWrapper.Id, outputStrings.Result.StandardOutput, outputStrings.Result.StandardError,
                 _processWrapper.StartTime,
-                _processWrapper.ExitTime);
+                _processWrapper.ExitTime,
+                canceled: _processWrapper.Canceled,
+                signal: _processWrapper.Signal);
 
             return result;
         }
@@ -280,7 +284,9 @@ public sealed class ExternalProcess : ISuspendableExternalProcess, IExternalProc
                 _processWrapper.StartTime,
                 _processWrapper.ExitTime,
                 await standardOutputStream,
-                await standardErrorStream
+                await standardErrorStream,
+                canceled: _processWrapper.Canceled,
+                signal: _processWrapper.Signal
             );
 
             return result;

--- a/src/CliInvoke/Processes/Internal/ControlAdapters/BaseProcessControlAdapter.cs
+++ b/src/CliInvoke/Processes/Internal/ControlAdapters/BaseProcessControlAdapter.cs
@@ -7,6 +7,8 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
    */
 
+using System.Runtime.InteropServices;
+
 using CliInvoke.Processes.Internal.Cancellation;
 
 namespace CliInvoke.Processes.Internal.ControlAdapters;
@@ -20,6 +22,13 @@ internal abstract class BaseProcessControlAdapter
     internal abstract void SetResourcePolicy(ProcessWrapper process,
         ProcessResourcePolicy? resourcePolicy);
     internal abstract void SetUserCredential(Process process, UserCredential credential);
+
+    /// <summary>
+    ///     Resolves the POSIX signal that terminated a process from its exit code, using the
+    ///     best-effort <c>ExitCode &gt; 128</c> heuristic. Returns <c>null</c> on platforms where
+    ///     signals are not represented this way.
+    /// </summary>
+    internal abstract PosixSignal? GetTerminatingSignal(int exitCode);
 
     internal virtual void ApplyConfiguration(ProcessWrapper process, ProcessConfiguration processConfiguration)
     {

--- a/src/CliInvoke/Processes/Internal/ControlAdapters/UnixProcessControlAdapter.cs
+++ b/src/CliInvoke/Processes/Internal/ControlAdapters/UnixProcessControlAdapter.cs
@@ -7,6 +7,7 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
    */
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 using CliInvoke.Processes.Internal.Cancellation;
@@ -101,8 +102,34 @@ internal partial class UnixProcessControlAdapter : BaseProcessControlAdapter
     {
     }
 
-    internal override PosixSignal? GetTerminatingSignal(int exitCode) =>
-        exitCode > 128 ? (PosixSignal)(exitCode - 128) : null;
+    internal override PosixSignal? GetTerminatingSignal(int exitCode)
+    {
+        if (exitCode <= 128)
+            return null;
+
+        // The BCL PosixSignal enum does not use OS signal numbers (it uses negative sentinels,
+        // e.g. SIGTERM = -4, SIGINT = -2), so a raw cast of (exitCode - 128) would yield a
+        // value that does not equal the corresponding enum member. Map the raw signal number
+        // to the correct PosixSignal explicitly instead.
+        int signalNumber = exitCode - 128;
+        return _signalByNumber.TryGetValue(signalNumber, out PosixSignal signal) ? signal : null;
+    }
+
+    private static readonly Dictionary<int, PosixSignal> _signalByNumber = new()
+    {
+        [1] = PosixSignal.SIGHUP,
+        [2] = PosixSignal.SIGINT,
+        [3] = PosixSignal.SIGQUIT,
+        [15] = PosixSignal.SIGTERM,
+        [17] = PosixSignal.SIGCHLD,
+        [18] = PosixSignal.SIGCONT,
+        [20] = PosixSignal.SIGTSTP,
+        [21] = PosixSignal.SIGTTIN,
+        [22] = PosixSignal.SIGTTOU,
+        [28] = PosixSignal.SIGWINCH,
+        // SIGKILL (9) is intentionally omitted: the PosixSignal enum has no SIGKILL member
+        // (it cannot be caught/trapped), so a SIGKILL death maps to null rather than a wrong value.
+    };
 
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]

--- a/src/CliInvoke/Processes/Internal/ControlAdapters/UnixProcessControlAdapter.cs
+++ b/src/CliInvoke/Processes/Internal/ControlAdapters/UnixProcessControlAdapter.cs
@@ -101,6 +101,9 @@ internal partial class UnixProcessControlAdapter : BaseProcessControlAdapter
     {
     }
 
+    internal override PosixSignal? GetTerminatingSignal(int exitCode) =>
+        exitCode > 128 ? (PosixSignal)(exitCode - 128) : null;
+
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]

--- a/src/CliInvoke/Processes/Internal/ControlAdapters/WindowsProcessControlAdapter.cs
+++ b/src/CliInvoke/Processes/Internal/ControlAdapters/WindowsProcessControlAdapter.cs
@@ -178,6 +178,8 @@ internal partial class WindowsProcessControlAdapter : BaseProcessControlAdapter
             process.StartInfo.LoadUserProfile = (bool)credential.LoadUserProfile;
     }
 
+    internal override PosixSignal? GetTerminatingSignal(int exitCode) => null;
+
     internal override Task<bool> SendInterruptSignalAsync(Process process,
         CancellationReason cancellationReason,
         ProcessExitConfiguration exitConfiguration, CancellationToken cancellationToken)

--- a/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
+++ b/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
@@ -444,10 +444,15 @@ internal class ProcessWrapper : Process
         {
             if (isGraceful)
             {
+                // Capture the cancellation task so its completion (and the resulting
+                // _cancellationReason assignment) can be awaited explicitly below.
+                Task<bool> cancelWithInterruptTask = CancelWithInterrupt(
+                    processExitConfiguration.TimeoutPolicy.TimeoutThreshold,
+                    processExitConfiguration, cancellationToken);
+
                 await Task.WhenAny([
                     WaitForExitSafeAsync(cancellationToken),
-                    CancelWithInterrupt(processExitConfiguration.TimeoutPolicy.TimeoutThreshold,
-                        processExitConfiguration, cancellationToken)
+                    cancelWithInterruptTask
                 ]);
 
                 await Task.WhenAny([
@@ -457,6 +462,14 @@ internal class ProcessWrapper : Process
                         cancellationToken),
                     WaitForExitSafeAsync(cancellationToken)
                 ]);
+
+                // Ensure the interrupt/timeout resolution has fully completed and persisted
+                // _cancellationReason before the caller reads Canceled. Otherwise the returned
+                // ProcessResult could observe Canceled as false even though the process was
+                // terminated by the cancellation machinery. Only wait when the process did not
+                // exit on its own, so fast-exiting processes are not held for the full timeout.
+                if (!HasExited && !cancelWithInterruptTask.IsCompleted)
+                    await cancelWithInterruptTask;
 
                 if (!HasExited && fallbackToForceful)
                     ForcefulExit();

--- a/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
+++ b/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
@@ -91,7 +91,7 @@ internal class ProcessWrapper : Process
     ///     machinery (timeout or requested cancellation) rather than the process exiting on its own.
     /// </summary>
     internal bool Canceled =>
-        !HasExited && _cancellationReason is CancellationReason.Timeout or CancellationReason.RequestedCancellation;
+        _cancellationReason is CancellationReason.Timeout or CancellationReason.RequestedCancellation;
 
     /// <summary>
     ///     The POSIX signal that terminated the process (Unix only), obtained via the control adapter.
@@ -597,6 +597,12 @@ internal class ProcessWrapper : Process
 
             if (HasExited)
                 return true;
+
+            // Reaching this point means the delay elapsed without the token being
+            // canceled, i.e. a graceful timeout. Persist the resolved reason before
+            // sending the interrupt so Canceled can be computed from it afterward.
+            cancellationReason = CancellationReason.Timeout;
+            _cancellationReason = cancellationReason;
 
             return  await ProcessControlAdapter.SendInterruptSignalAsync(this,
                 cancellationReason, exitConfiguration, cancellationToken);

--- a/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
+++ b/src/CliInvoke/Processes/Internal/ProcessWrapper.cs
@@ -9,6 +9,7 @@
 
 using System.ComponentModel;
 using System.IO;
+using System.Runtime.InteropServices;
 
 using CliInvoke.Processes.Internal.Cancellation;
 using CliInvoke.Processes.Internal.ControlAdapters;
@@ -53,6 +54,9 @@ internal class ProcessWrapper : Process
     // Synchronisation primitive to prevent simultaneous cancellation attempts
     internal readonly SemaphoreSlim _cancellationSemaphore = new(1, 1);
 
+    // Resolved cancellation reason, persisted across the wait so Canceled can be computed afterward.
+    private CancellationReason _cancellationReason = CancellationReason.NotKnown;
+
     internal ProcessWrapper(ProcessConfiguration configuration,
         FileInfo resolvedFilePath)
     {
@@ -81,6 +85,18 @@ internal class ProcessWrapper : Process
     internal new int Id { get; private set; }
 
     internal new string ProcessName { get; private set; }
+
+    /// <summary>
+    ///     A value indicating whether the library terminated the process via its cancellation
+    ///     machinery (timeout or requested cancellation) rather than the process exiting on its own.
+    /// </summary>
+    internal bool Canceled =>
+        !HasExited && _cancellationReason is CancellationReason.Timeout or CancellationReason.RequestedCancellation;
+
+    /// <summary>
+    ///     The POSIX signal that terminated the process (Unix only), obtained via the control adapter.
+    /// </summary>
+    internal PosixSignal? Signal => ProcessControlAdapter.GetTerminatingSignal(ExitCode);
 
     
     private void OnStarted(object? sender, EventArgs e)
@@ -524,6 +540,7 @@ internal class ProcessWrapper : Process
         try
         {
             await WaitForExitSafeAsync(actualCancellationToken);
+            _cancellationReason = cancellationReason;
         }
         catch (Exception exception)
         {
@@ -532,6 +549,7 @@ internal class ProcessWrapper : Process
                 CancellationHelper.CalculateExpectedExitTime(exitConfiguration);
             CancellationHelper.HandleCancellationExceptions(currentExpectedExitTime,
                 cancellationReason, exitConfiguration, exception);
+            _cancellationReason = cancellationReason;
         }
         finally
         {
@@ -594,6 +612,7 @@ internal class ProcessWrapper : Process
             CancellationHelper.HandleCancellationExceptions(currentExpectedExitTime,
                 cancellationReason,
                 exitConfiguration, exception);
+            _cancellationReason = cancellationReason;
         }
         finally
         {

--- a/tests/CliInvoke.Tests/Builders/ProcessConfigurationBuilderTests.cs
+++ b/tests/CliInvoke.Tests/Builders/ProcessConfigurationBuilderTests.cs
@@ -235,7 +235,9 @@ public class ProcessConfigurationBuilderTests
         // Arrange
         IProcessConfigurationBuilder builder = new ProcessConfigurationBuilder("test.exe");
         string input = "\\\n\t\r\"";
-        string expected = "\"\\\\\\n\\t\\r\\\"";
+        // EscapeForCmd drops bare newlines/carriage returns, passes backslash and tab
+        // through, and doubles embedded quotes; the result is then wrapped in quotes.
+        string expected = "\"\\" + "\t" + "\"\"\"";
 
         // Act
         builder.ConfigureArguments(spec => spec.Add(input, escape: true));
@@ -299,7 +301,9 @@ public class ProcessConfigurationBuilderTests
         // Arrange
         IProcessConfigurationBuilder builder = new ProcessConfigurationBuilder("test.exe");
         string[] values = ["a\nb", "c\"d"];
-        const string expected = "\"a\\nb c\\\"d\"";
+        // Each value is escaped with EscapeForCmd (newline dropped, quote doubled), joined
+        // with a space, then the whole result is wrapped in quotes.
+        const string expected = "\"ab c\"\"d\"";
 
         // Act
         builder.ConfigureArguments(spec => spec.AddEnumerable(values, escape: true));

--- a/tests/CliInvoke.Tests/CountingExternalProcessFactory.cs
+++ b/tests/CliInvoke.Tests/CountingExternalProcessFactory.cs
@@ -7,6 +7,7 @@
     file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+using System.Runtime.InteropServices;
 using CliInvoke.Core.Factories;
 using CliInvoke.Core.Processes;
 
@@ -98,6 +99,10 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
 
         public bool HasStarted { get; private set; }
 
+        public bool Canceled { get; set; }
+
+        public PosixSignal? Signal { get; set; }
+
         public bool IsDisposed { get; internal set; }
 
         public event EventHandler? Started;
@@ -140,7 +145,8 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
             DateTime now = DateTime.UtcNow;
             return Task.FromResult(new ProcessResult(
                 Configuration.TargetFilePath, exitCode: 0, processId: 0,
-                startTime: now, exitTime: now));
+                startTime: now, exitTime: now,
+                canceled: Canceled, signal: Signal));
         }
 
         public Task<BufferedProcessResult> CaptureBufferedResultAsync(CancellationToken cancellationToken)
@@ -149,7 +155,8 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
             return Task.FromResult(new BufferedProcessResult(
                 Configuration.TargetFilePath, exitCode: 0, processId: 0,
                 standardOutput: string.Empty, standardError: string.Empty,
-                startTime: now, exitTime: now));
+                startTime: now, exitTime: now,
+                canceled: Canceled, signal: Signal));
         }
 
         public Task<PipedProcessResult> CapturePipedResultAsync(CancellationToken cancellationToken)
@@ -158,7 +165,8 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
             return Task.FromResult(new PipedProcessResult(
                 Configuration.TargetFilePath, exitCode: 0, processId: 0,
                 startTime: now, exitTime: now,
-                standardOutput: Stream.Null, standardError: Stream.Null));
+                standardOutput: Stream.Null, standardError: Stream.Null,
+                canceled: Canceled, signal: Signal));
         }
 
         public Task Kill() => Task.CompletedTask;

--- a/tests/CliInvoke.Tests/CountingExternalProcessFactory.cs
+++ b/tests/CliInvoke.Tests/CountingExternalProcessFactory.cs
@@ -22,6 +22,18 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
 {
     private int _createCount;
 
+    /// <summary>
+    ///     When set, the next stub process will report this value for its
+    ///     <c>Canceled</c> state (used by TK006 tests).
+    /// </summary>
+    public bool DefaultCanceled { get; set; }
+
+    /// <summary>
+    ///     When set, the next stub process will report this value for
+    ///     <see cref="ProcessResult.Signal"/>-derived results (used by TK006 tests).
+    /// </summary>
+    public PosixSignal? DefaultSignal { get; set; }
+
     public int CreateCount => _createCount;
 
     public ProcessConfiguration? LastConfiguration { get; private set; }
@@ -39,7 +51,11 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
     {
         _createCount++;
         LastConfiguration = configuration;
-        return new StubExternalProcess(configuration, ThrowOnStart);
+        return new StubExternalProcess(configuration, ThrowOnStart)
+        {
+            Canceled = DefaultCanceled,
+            Signal = DefaultSignal
+        };
     }
 
     public IExternalProcess CreateExternalProcess(ProcessConfiguration configuration,
@@ -48,7 +64,11 @@ internal sealed class CountingExternalProcessFactory : IExternalProcessFactory, 
         _createCount++;
         LastConfiguration = configuration;
         LastExitConfiguration = exitConfiguration;
-        return new StubExternalProcess(configuration, exitConfiguration, ThrowOnStart);
+        return new StubExternalProcess(configuration, exitConfiguration, ThrowOnStart)
+        {
+            Canceled = DefaultCanceled,
+            Signal = DefaultSignal
+        };
     }
 
     public void Reset()

--- a/tests/CliInvoke.Tests/Internal/Helpers/ProcessTestHelper.cs
+++ b/tests/CliInvoke.Tests/Internal/Helpers/ProcessTestHelper.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 using CliInvoke.Processes.Internal;
 using CliInvoke.Tests.Internal.Constants;
 
@@ -72,6 +74,26 @@ internal class ProcessTestHelper
 
         return binaryPath;
     }
+
+    /// <summary>
+    ///     Delivers <see cref="PosixSignal.SIGTERM"/> to the process with the given id.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="System.Diagnostics.Process.Kill"/> terminates a Unix process with
+    ///     <c>SIGKILL</c> (exit code 137), not <c>SIGTERM</c> (exit code 143), so it cannot be
+    ///     used to exercise the signal-trapping helper. This sends the expected signal directly.
+    /// </remarks>
+    internal static void SendTerminationSignal(int processId)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        const int Sigterm = 15;
+        _ = kill(processId, Sigterm);
+    }
+
+    [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+    private static extern int kill(int pid, int sig);
 
     /// <summary>
     ///     Creates a <see cref="ProcessWrapper"/> configured to launch the signal-trapping helper

--- a/tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs
+++ b/tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs
@@ -49,4 +49,41 @@ public class GracefulCancellationTests
                 File.Delete(markerPath);
         }
     }
+
+    [Test]
+    public async Task GracefulTimeout_Canceled_IsTrue()
+    {
+        string markerPath = Path.Combine(Path.GetTempPath(),
+            $"cliinvoke-graceful-canceled-{Guid.NewGuid():N}.marker");
+
+        const int gracefulTimeoutSeconds = 2;
+
+        ProcessWrapper process = ProcessTestHelper.CreateSignalTrappingProcess(markerPath, sleepSeconds: 5);
+
+        process.Start();
+
+        ProcessExitConfiguration exitConfiguration = new ProcessExitConfiguration(
+            ProcessTimeoutPolicy.FromTimeSpan(TimeSpan.FromSeconds(gracefulTimeoutSeconds)),
+            cancellationThrowsException: false);
+
+        try
+        {
+            await process.WaitForExitOrGracefulTimeoutAsync(exitConfiguration, CancellationToken.None);
+
+            await Assert.That(process.HasExited).IsTrue();
+            await Assert.That(process.Canceled).IsTrue();
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                try { process.Kill(true); } catch { process.Kill(); }
+            }
+
+            process.Dispose();
+
+            if (File.Exists(markerPath))
+                File.Delete(markerPath);
+        }
+    }
 }

--- a/tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs
+++ b/tests/CliInvoke.Tests/Invokers/Cancellation/GracefulCancellationTests.cs
@@ -1,4 +1,8 @@
+using CliInvoke;
+using CliInvoke.Core;
+using CliInvoke.Processes;
 using CliInvoke.Processes.Internal;
+using CliInvoke.Tests.Internal.Helpers;
 
 namespace CliInvoke.Tests.Invokers.Cancellation;
 
@@ -82,6 +86,41 @@ public class GracefulCancellationTests
 
             process.Dispose();
 
+            if (File.Exists(markerPath))
+                File.Delete(markerPath);
+        }
+    }
+
+    [Test]
+    public async Task GracefulTimeout_ProcessResult_Canceled_IsTrue()
+    {
+        // Regression test: the ProcessResult returned to the caller must report Canceled as true
+        // after a graceful timeout cancellation. This guards against a race where the result was
+        // built before ProcessWrapper.Canceled reflected the persisted cancellation reason.
+        string markerPath = Path.Combine(Path.GetTempPath(),
+            $"cliinvoke-graceful-result-canceled-{Guid.NewGuid():N}.marker");
+
+        const int gracefulTimeoutSeconds = 2;
+
+        string helperPath = ProcessTestHelper.GetSignalTrappingHelperPath();
+        using ProcessConfiguration configuration = new(helperPath, $"\"{markerPath}\" 5");
+
+        ProcessExitConfiguration exitConfiguration = new(
+            ProcessTimeoutPolicy.FromTimeSpan(TimeSpan.FromSeconds(gracefulTimeoutSeconds)),
+            cancellationThrowsException: false);
+
+        try
+        {
+            using ExternalProcess process = new(new FilePathResolver(), configuration, exitConfiguration);
+            process.Start();
+
+            ProcessResult result = await process.WaitForExitOrTimeoutAsync(CancellationToken.None);
+
+            await Assert.That(process.HasExited).IsTrue();
+            await Assert.That(result.Canceled).IsTrue();
+        }
+        finally
+        {
             if (File.Exists(markerPath))
                 File.Delete(markerPath);
         }

--- a/tests/CliInvoke.Tests/Middleware/ChainDisposalTests.cs
+++ b/tests/CliInvoke.Tests/Middleware/ChainDisposalTests.cs
@@ -10,7 +10,7 @@ public class ChainDisposalTests
     {
         MemoryStream stdout = new MemoryStream();
         MemoryStream stderr = new MemoryStream();
-        PipedProcessResult pipedResult = new PipedProcessResult("test.exe", 0, 1, DateTime.UtcNow, DateTime.UtcNow, stdout, stderr);
+        PipedProcessResult pipedResult = new PipedProcessResult("test.exe", 0, 1, DateTime.UtcNow, DateTime.UtcNow, stdout, stderr, canceled: false, signal: null);
 
         MiddlewareChain chain = new MiddlewareChain(
             new List<IProcessMiddleware>(),
@@ -37,7 +37,7 @@ public class ChainDisposalTests
     {
         MemoryStream stdout = new MemoryStream();
         MemoryStream stderr = new MemoryStream();
-        PipedProcessResult pipedResult = new PipedProcessResult("test.exe", 0, 1, DateTime.UtcNow, DateTime.UtcNow, stdout, stderr);
+        PipedProcessResult pipedResult = new PipedProcessResult("test.exe", 0, 1, DateTime.UtcNow, DateTime.UtcNow, stdout, stderr, canceled: false, signal: null);
 
         MiddlewareChain chain = new MiddlewareChain(
             new List<IProcessMiddleware>(),

--- a/tests/CliInvoke.Tests/Primitives/ProcessResultEqualityTests.cs
+++ b/tests/CliInvoke.Tests/Primitives/ProcessResultEqualityTests.cs
@@ -87,10 +87,9 @@ public class ProcessResultEqualityTests
             piped.Dispose();
         }
     }
-}
 
-[Test]
-public async Task ProcessResult_CanceledDifference_AffectsEquality()
+    [Test]
+    public async Task ProcessResult_CanceledDifference_AffectsEquality()
 {
     ProcessResult notCanceled = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
         new DateTime(2026, 1, 1, 0, 0, 1), canceled: false, signal: null);
@@ -116,4 +115,5 @@ public async Task ProcessResult_SignalDifference_AffectsEquality()
     await Assert.That(noSignal.Equals(signaled)).IsFalse();
     await Assert.That(signaled.Equals(noSignal)).IsFalse();
     await Assert.That(noSignal.GetHashCode()).IsNotEqualTo(signaled.GetHashCode());
+    }
 }

--- a/tests/CliInvoke.Tests/Primitives/ProcessResultEqualityTests.cs
+++ b/tests/CliInvoke.Tests/Primitives/ProcessResultEqualityTests.cs
@@ -1,12 +1,16 @@
 namespace CliInvoke.Tests.Primitives;
 
+using System.Runtime.InteropServices;
+
 public class ProcessResultEqualityTests
 {
     private static ProcessResult MakeBase()
-        => new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0), new DateTime(2026, 1, 1, 0, 0, 1));
+        => new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0), new DateTime(2026, 1, 1, 0, 0, 1),
+            canceled: false, signal: null);
 
     private static BufferedProcessResult MakeBuffered()
-        => new("foo.exe", 0, 1, "out", "err", new DateTime(2026, 1, 1, 0, 0, 0), new DateTime(2026, 1, 1, 0, 0, 1));
+        => new("foo.exe", 0, 1, "out", "err", new DateTime(2026, 1, 1, 0, 0, 0), new DateTime(2026, 1, 1, 0, 0, 1),
+            canceled: false, signal: null);
 
     [Test]
     public async Task ProcessResult_EqualInstances_AreSymmetric()
@@ -38,9 +42,9 @@ public class ProcessResultEqualityTests
         MemoryStream standardError = new();
 
         PipedProcessResult a = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
-            new DateTime(2026, 1, 1, 0, 0, 1), standardOutput, standardError);
+            new DateTime(2026, 1, 1, 0, 0, 1), standardOutput, standardError, canceled: false, signal: null);
         PipedProcessResult b = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
-            new DateTime(2026, 1, 1, 0, 0, 1), standardOutput, standardError);
+            new DateTime(2026, 1, 1, 0, 0, 1), standardOutput, standardError, canceled: false, signal: null);
 
         try
         {
@@ -70,7 +74,7 @@ public class ProcessResultEqualityTests
     public async Task PipedProcessResult_ComparedToBaseProcessResult_IsSymmetric()
     {
         PipedProcessResult piped = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
-            new DateTime(2026, 1, 1, 0, 0, 1), new MemoryStream(), new MemoryStream());
+            new DateTime(2026, 1, 1, 0, 0, 1), new MemoryStream(), new MemoryStream(), canceled: false, signal: null);
         ProcessResult baseResult = MakeBase();
 
         try
@@ -83,4 +87,33 @@ public class ProcessResultEqualityTests
             piped.Dispose();
         }
     }
+}
+
+[Test]
+public async Task ProcessResult_CanceledDifference_AffectsEquality()
+{
+    ProcessResult notCanceled = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
+        new DateTime(2026, 1, 1, 0, 0, 1), canceled: false, signal: null);
+    ProcessResult canceled = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
+        new DateTime(2026, 1, 1, 0, 0, 1), canceled: true, signal: null);
+
+    await Assert.That(notCanceled.Equals(canceled)).IsFalse();
+    await Assert.That(canceled.Equals(notCanceled)).IsFalse();
+    await Assert.That(notCanceled.GetHashCode()).IsNotEqualTo(canceled.GetHashCode());
+}
+
+[Test]
+public async Task ProcessResult_SignalDifference_AffectsEquality()
+{
+    ProcessResult noSignal = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
+        new DateTime(2026, 1, 1, 0, 0, 1), canceled: false, signal: null);
+
+#pragma warning disable CA1416
+    ProcessResult signaled = new("foo.exe", 0, 1, new DateTime(2026, 1, 1, 0, 0, 0),
+        new DateTime(2026, 1, 1, 0, 0, 1), canceled: false, signal: PosixSignal.SIGTERM);
+#pragma warning restore CA1416
+
+    await Assert.That(noSignal.Equals(signaled)).IsFalse();
+    await Assert.That(signaled.Equals(noSignal)).IsFalse();
+    await Assert.That(noSignal.GetHashCode()).IsNotEqualTo(signaled.GetHashCode());
 }

--- a/tests/CliInvoke.Tests/Processes/ProcessResultCanceledSignalTests.cs
+++ b/tests/CliInvoke.Tests/Processes/ProcessResultCanceledSignalTests.cs
@@ -143,8 +143,8 @@ public class ProcessResultCanceledSignalTests : IDisposable
     [Test]
     public async Task Unix_SignalTrappingHelper_KilledBySigterm_ReportsSignal()
     {
-        // Windows has no POSIX signals; Signal null is guaranteed by [UnsupportedOSPlatform]
-        // plus code review and is not CI-exercised (no Windows CI build).
+        // Windows has no POSIX signals; Signal is null by design on Windows
+        // (the property is supported on all platforms and simply returns null there).
         if (OperatingSystem.IsWindows())
             return;
 

--- a/tests/CliInvoke.Tests/Processes/ProcessResultCanceledSignalTests.cs
+++ b/tests/CliInvoke.Tests/Processes/ProcessResultCanceledSignalTests.cs
@@ -159,8 +159,9 @@ public class ProcessResultCanceledSignalTests : IDisposable
             // Give the helper a moment to be running before delivering SIGTERM.
             await Task.Delay(200, CancellationToken.None);
 
-            // On Unix, Process.Kill() sends SIGTERM.
-            process.Kill();
+            // Process.Kill() terminates a Unix process with SIGKILL (exit code 137), not
+            // SIGTERM (exit code 143), so send the expected signal explicitly.
+            ProcessTestHelper.SendTerminationSignal(process.Id);
 
             await process.WaitForExitAsync(CancellationToken.None);
 

--- a/tests/CliInvoke.Tests/Processes/ProcessResultCanceledSignalTests.cs
+++ b/tests/CliInvoke.Tests/Processes/ProcessResultCanceledSignalTests.cs
@@ -1,0 +1,194 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+using CliInvoke;
+using CliInvoke.Processes.Internal;
+using System.Runtime.InteropServices;
+
+namespace CliInvoke.Tests.Processes;
+
+/// <summary>
+///     Validates the <see cref="ProcessResult.Canceled"/> and
+///     <see cref="ProcessResult.Signal"/> model: truth conditions (D003),
+///     orthogonality (D006), and an OS-gated Unix SIGTERM integration (D005/D009).
+/// </summary>
+public class ProcessResultCanceledSignalTests : IDisposable
+{
+    private readonly ProcessConfiguration _configuration;
+
+    public ProcessResultCanceledSignalTests()
+    {
+        _configuration = ProcessConfigurationFactory.Create(ProcessTestHelper.GetTargetFilePath(), string.Empty);
+    }
+
+    public void Dispose() => _configuration.Dispose();
+
+    private static InvocationContext RawContext(ProcessConfiguration configuration)
+        => new(configuration, ProcessExitConfiguration.CreateGraceful(), InvocationMode.Raw, CancellationToken.None);
+
+    // ---- Mock-injected truth-condition tests (D003) ----
+
+    [Test]
+    public async Task Raw_Result_Carries_Injected_Canceled_True()
+    {
+        CountingExternalProcessFactory factory = new() { DefaultCanceled = true };
+        ProcessInvocationPipeline pipeline = new(factory);
+
+        ProcessResult result = await pipeline.InvokeAsync<ProcessResult>(RawContext(_configuration));
+
+        await Assert.That(result.Canceled).IsTrue();
+        await Assert.That(result.Signal).IsNull();
+    }
+
+    [Test]
+    public async Task Raw_Result_Carries_Injected_Canceled_False()
+    {
+        CountingExternalProcessFactory factory = new() { DefaultCanceled = false };
+        ProcessInvocationPipeline pipeline = new(factory);
+
+        ProcessResult result = await pipeline.InvokeAsync<ProcessResult>(RawContext(_configuration));
+
+        await Assert.That(result.Canceled).IsFalse();
+    }
+
+    [Test]
+    public async Task Buffered_Result_Carries_Injected_Canceled_True()
+    {
+        CountingExternalProcessFactory factory = new() { DefaultCanceled = true };
+        ProcessInvocationPipeline pipeline = new(factory);
+        InvocationContext ctx = new(_configuration, ProcessExitConfiguration.CreateGraceful(),
+            InvocationMode.Buffered, CancellationToken.None);
+
+        BufferedProcessResult result = await pipeline.InvokeAsync<BufferedProcessResult>(ctx);
+
+        await Assert.That(result.Canceled).IsTrue();
+    }
+
+    [Test]
+    public async Task Piped_Result_Carries_Injected_Canceled_True()
+    {
+        CountingExternalProcessFactory factory = new() { DefaultCanceled = true };
+        ProcessInvocationPipeline pipeline = new(factory);
+        InvocationContext ctx = new(_configuration, ProcessExitConfiguration.CreateGraceful(),
+            InvocationMode.Piped, CancellationToken.None);
+
+        PipedProcessResult result = await pipeline.InvokeAsync<PipedProcessResult>(ctx);
+
+        await Assert.That(result.Canceled).IsTrue();
+    }
+
+    // ---- Orthogonality tests (D006) ----
+
+    [Test]
+    public async Task NonNull_Signal_Does_Not_Force_Canceled()
+    {
+        CountingExternalProcessFactory factory = new()
+        {
+            DefaultCanceled = false,
+            DefaultSignal = PosixSignal.SIGTERM
+        };
+        ProcessInvocationPipeline pipeline = new(factory);
+
+        ProcessResult result = await pipeline.InvokeAsync<ProcessResult>(RawContext(_configuration));
+
+        await Assert.That(result.Signal).IsEqualTo(PosixSignal.SIGTERM);
+        await Assert.That(result.Canceled).IsFalse();
+    }
+
+    [Test]
+    public async Task Canceled_True_Does_Not_Require_Signal()
+    {
+        CountingExternalProcessFactory factory = new()
+        {
+            DefaultCanceled = true,
+            DefaultSignal = null
+        };
+        ProcessInvocationPipeline pipeline = new(factory);
+
+        ProcessResult result = await pipeline.InvokeAsync<ProcessResult>(RawContext(_configuration));
+
+        await Assert.That(result.Canceled).IsTrue();
+        await Assert.That(result.Signal).IsNull();
+    }
+
+    // ---- FireAndForget always false/null (T011) ----
+
+    [Test]
+    public async Task FireAndForget_Result_Has_Canceled_False_And_Signal_Null()
+    {
+        // FireAndForget ignores injected values and hard-codes canceled:false, signal:null (TK004).
+        CountingExternalProcessFactory factory = new()
+        {
+            DefaultCanceled = true,
+            DefaultSignal = PosixSignal.SIGTERM
+        };
+        ProcessInvocationPipeline pipeline = new(factory);
+        InvocationContext ctx = new(_configuration, ProcessExitConfiguration.CreateGraceful(),
+            InvocationMode.FireAndForget, CancellationToken.None);
+
+        ProcessResult result = await pipeline.InvokeAsync<ProcessResult>(ctx);
+
+        await Assert.That(result.Canceled).IsFalse();
+        await Assert.That(result.Signal).IsNull();
+    }
+
+    // ---- OS-gated Unix integration (D003/D005/D009) ----
+
+    [Test]
+    public async Task Unix_SignalTrappingHelper_KilledBySigterm_ReportsSignal()
+    {
+        // Windows has no POSIX signals; Signal null is guaranteed by [UnsupportedOSPlatform]
+        // plus code review and is not CI-exercised (no Windows CI build).
+        if (OperatingSystem.IsWindows())
+            return;
+
+        string markerPath = Path.Combine(Path.GetTempPath(),
+            $"cliinvoke-canceled-signal-{Guid.NewGuid():N}.marker");
+
+        ProcessWrapper process = ProcessTestHelper.CreateSignalTrappingProcess(markerPath, sleepSeconds: 5);
+        process.Start();
+
+        try
+        {
+            // Give the helper a moment to be running before delivering SIGTERM.
+            await Task.Delay(200, CancellationToken.None);
+
+            // On Unix, Process.Kill() sends SIGTERM.
+            process.Kill();
+
+            await process.WaitForExitAsync(CancellationToken.None);
+
+            await Assert.That(process.HasExited).IsTrue();
+            await Assert.That(process.ExitCode).IsEqualTo(143);
+            await Assert.That(process.Signal).IsEqualTo(PosixSignal.SIGTERM);
+
+            // Externally killed -> not library-canceled.
+            await Assert.That(process.Canceled).IsFalse();
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                try
+                {
+                    process.Kill(true);
+                }
+                catch
+                {
+                    process.Kill();
+                }
+            }
+
+            process.Dispose();
+
+            if (File.Exists(markerPath))
+                File.Delete(markerPath);
+        }
+    }
+}


### PR DESCRIPTION
## What changed
This PR adds ``Canceled`` and ``Signal`` properties to ``ProcessResult`` and derived types along with updated logic to enable capturing the information and providing it in the result types.

## Why it was changed
.NET 11 adds useful new properties to its new result model type``ProcessExitStatus`` . Since this type is sealed and not aligned with CliInvoke's differing levels of result models for different levels of output information (Basic, String based, Stream based), it makes more sense for CliInvoke to adopt these new properties than split the result type ecosystem with a hybrid result regime (``ProcessExitStatus`` for basic, ``BufferedProcessResult`` for String based output, and ``PipedProcessResult`` for Stream based output).

The new properties, ``Canceled`` and ``Signal``, indicate whether the process was cancelled (by the user via requested cancellation or via timeout triggered cancellation) and what Posix Signal was sent to the process during process exit respectively.

These property additions to ``ProcessResult`` and derived types bring greater clarity to Process running in case of cancellation and exit.

The ``Signal`` property is nullable and returns null on Windows due to lack of OS support for this paradigm.

**Note**: Due to limitations in the Process APIs on .NET 10, ``ProcessResult``'s ``Signal`` property is more of a heuristic property than a definitive result. .NET 11 and newer will enable more accurate and reliable retrieval of ``Signal`` information in CliInvoke v3 in a future .NET 11 supporting update.

## Testing

- [x] `dotnet test` passes locally on the supported TFMs
- [x] New or updated tests are included for the change
- [x] Behavior-affecting changes are covered by tests


## Documentation

- [x] README, docs/, or XML doc comments updated (if applicable)
- [ ] VERSION_HISTORY.md updated (if user-visible)
- [ ] No docs change needed


## Contribution Policy compliance

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/alastairlundy/CliInvoke/blob/main/CONTRIBUTING.md)
- [x] My branch is up to date with `main` and the diff is focused
- [x] Commit messages are clear and describe the change
- [x] I have not introduced secrets, credentials, or copyrighted content
- [x] For changes that affect resource-owning types, I followed the
      disposal conventions in the README


## Authorship

- [ ] This PR was written entirely by a human (no AI assistance)
- [x] This PR was Co-Authored by AI (the human author reviewed,
      edited, and takes responsibility for the final code; commits
      include the appropriate `Co-authored-by:` trailer(s))

If this PR was Co-Authored by AI, please also fill in the following:

- **AI agent used:**
GitHub Copilot App

- **AI model used:**
Hy3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process results now indicate whether execution was canceled.
  * POSIX termination signals are reported when available, including signal details for externally terminated processes.
  * Signal information is safely exposed across platforms; Windows reports no terminating signal.

* **Bug Fixes**
  * Cancellation status is now preserved for timeout and requested-cancellation scenarios.
  * Equality and hash comparisons now account for cancellation and signal information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->