### PR TITLE
Pin GitHub Actions dependencies in docs-publish.yml

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -17,13 +17,13 @@ jobs:
     environment:
       name: github-pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 10.0.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.nuget/packages
@@ -35,7 +35,7 @@ jobs:
           dotnet build src/CliInvoke.Core -c Release
           dotnet build src/CliInvoke -c Release
           dotnet build src/CliInvoke.Specializations -c Release
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: site/.lunet/build/cache
           key: lunet-${{ hashFiles('site/config.scriban') }}
@@ -47,8 +47,8 @@ jobs:
       - name: Build site
         working-directory: site
         run: lunet --stacktrace build
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site/.lunet/build/www
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## What changed

Pinned all GitHub Actions used in `.github/workflows/docs-publish.yml` to full commit SHAs.

## Why it was changed

Resolves code scanning alerts 51-58 (`Pinned-Dependencies`). The workflow previously used mutable tag references (`@v4`, `@v5`, `@v3`) which is a supply-chain security risk. All other workflow files were already pinned.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@3d3c42e...` (v7.0.1) |
| `actions/setup-dotnet` | `@v4` | `@a98b568...` (v6.0.0) |
| `actions/cache` | `@v4` (×2) | `@0057852...` (v4) |
| `actions/configure-pages` | `@v5` | `@983d773...` (v5) |
| `actions/upload-pages-artifact` | `@v3` | `@56afc60...` (v3) |
| `actions/deploy-pages` | `@v4` | `@d6db901...` (v4) |

Checkout and setup-dotnet were also upgraded to v7 and v6 respectively to align with the other workflows.

## Testing

- [x] Solution builds successfully
- [ ] No code changes — workflow-only file modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing process to use fixed, versioned action references.
  * Documentation builds, caching, and deployment steps remain unchanged while benefiting from more consistent and predictable publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->