### PR TITLE
Add FsCheck property-based fuzz tests (addresses Code Scanning alert #15)

### DIFF
--- a/tests/CliInvoke.Tests/CliInvoke.Tests.csproj
+++ b/tests/CliInvoke.Tests/CliInvoke.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="TUnit" />
     <PackageReference Include="Bogus" />
     <PackageReference Include="DotExtensions" />
+    <PackageReference Include="FsCheck" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\CliInvoke.Core\CliInvoke.Core.csproj" />

--- a/tests/CliInvoke.Tests/Fuzzing/ArgumentEscaperFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ArgumentEscaperFuzzTests.cs
@@ -1,0 +1,192 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Linq;
+using CliInvoke.Core.Internal;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="ArgumentEscaper"/>.
+/// </summary>
+public class ArgumentEscaperFuzzTests
+{
+    [Test]
+    public void EscapeInner_NullOrEmpty_ReturnsEmpty()
+    {
+        Prop.ForAll<string?>(value =>
+                {
+                    if (value is not null and { Length: > 0 })
+                        return true;
+
+                    string result = ArgumentEscaper.EscapeInner(value);
+                    return result == string.Empty;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeInner_PlainAlphanumeric_IsUnchanged()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) ||
+                    Enumerable.Any(value, c => !(char.IsLetterOrDigit(c) || c == '_' || c == '-' || c == '.')))
+                    return true;
+
+                string escaped = ArgumentEscaper.EscapeInner(value);
+                return escaped == value;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeInner_DoubledQuotesForEmbeddedQuotes()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || !value.Contains('"'))
+                    return true;
+
+                string escaped = ArgumentEscaper.EscapeInner(value);
+
+                int quoteCount = 0;
+                foreach (char c in escaped)
+                {
+                    if (c == '"')
+                        quoteCount++;
+                }
+
+                return quoteCount % 2 == 0;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeInner_BackslashesBeforeQuoteAreDoubled()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value))
+                    return true;
+
+                string escaped = ArgumentEscaper.EscapeInner(value);
+
+                for (int i = 0; i < escaped.Length; i++)
+                {
+                    if (escaped[i] == '"' && i > 0)
+                    {
+                        int bsCount = 0;
+                        int j = i - 1;
+                        while (j >= 0 && escaped[j] == '\\')
+                        {
+                            bsCount++;
+                            j--;
+                        }
+
+                        if (bsCount % 2 != 0)
+                            return false;
+                    }
+                }
+
+                return true;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeInner_TrailingBackslashesAreDoubled()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value))
+                    return true;
+
+                string escaped = ArgumentEscaper.EscapeInner(value);
+
+                int trailingBs = 0;
+                for (int i = escaped.Length - 1; i >= 0 && escaped[i] == '\\'; i--)
+                    trailingBs++;
+
+                return trailingBs % 2 == 0;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeInner_NewlinesAreDropped()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value))
+                    return true;
+
+                string escaped = ArgumentEscaper.EscapeInner(value);
+                return !escaped.Contains('\n') && !escaped.Contains('\r');
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void NeedsQuoting_NullOrEmpty_ReturnsFalse()
+    {
+        Prop.ForAll<string?>(value =>
+                {
+                    if (value is not null and { Length: > 0 })
+                        return true;
+
+                    return !ArgumentEscaper.NeedsQuoting(value);
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void NeedsQuoting_PlainAlphanumeric_ReturnsFalse()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) ||
+                    Enumerable.Any(value, c => !(char.IsLetterOrDigit(c) || c == '_' || c == '-' || c == '.')))
+                    return true;
+
+                return !ArgumentEscaper.NeedsQuoting(value);
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void NeedsQuoting_Whitespace_ReturnsTrue()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || !Enumerable.Any(value, char.IsWhiteSpace))
+                    return true;
+
+                return ArgumentEscaper.NeedsQuoting(value);
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void NeedsQuoting_SpecialChars_ReturnsTrue()
+    {
+        char[] specialChars = ['"', '\\', '&', '|', '<', '>', '^', '%'];
+
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || !Enumerable.Any(value, c => specialChars.Contains(c)))
+                    return true;
+
+                return ArgumentEscaper.NeedsQuoting(value);
+            })
+            .QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/CliInvoke.Tests/Fuzzing/ArgumentTokenizerFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ArgumentTokenizerFuzzTests.cs
@@ -51,18 +51,19 @@ public class ArgumentTokenizerFuzzTests
     [Test]
     public void Tokenize_SpaceSeparatedWords_ProducesCorrectCount()
     {
-        Prop.ForAll<string>(value =>
+        Prop.ForAll<string>(word1 =>
             {
-                if (string.IsNullOrWhiteSpace(value) || value.Any(char.IsWhiteSpace) || value.Contains('"'))
-                    return true;
+                return Prop.ForAll<string>(word2 =>
+                    {
+                        if (string.IsNullOrWhiteSpace(word1) || string.IsNullOrWhiteSpace(word2) ||
+                            word1.Any(char.IsWhiteSpace) || word2.Any(char.IsWhiteSpace) ||
+                            word1.Contains('"') || word2.Contains('"'))
+                            return true;
 
-                string[] parts = value.Split(' ');
-                int expectedCount = parts.Count(p => p.Length > 0);
-                if (expectedCount < 2)
-                    return true;
-
-                IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(value);
-                return tokens.Count == expectedCount;
+                        string input = word1 + " " + word2;
+                        IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(input);
+                        return tokens.Count == 2 && tokens[0] == word1 && tokens[1] == word2;
+                    });
             })
             .QuickCheckThrowOnFailure();
     }
@@ -90,9 +91,9 @@ public class ArgumentTokenizerFuzzTests
                 if (string.IsNullOrWhiteSpace(value) || value.Contains('"'))
                     return true;
 
-                string input = "\"hello\"\"world\"";
+                string input = "\"" + value + "\"\"" + value + "\"";
                 IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(input);
-                return tokens.Count == 1 && tokens[0] == "hello\"world";
+                return tokens.Count == 1 && tokens[0] == value + "\"" + value;
             })
             .QuickCheckThrowOnFailure();
     }

--- a/tests/CliInvoke.Tests/Fuzzing/ArgumentTokenizerFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ArgumentTokenizerFuzzTests.cs
@@ -1,0 +1,120 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using CliInvoke.Core.Internal;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="ArgumentTokenizer"/>.
+/// </summary>
+public class ArgumentTokenizerFuzzTests
+{
+    [Test]
+    public void Tokenize_NullOrEmptyOrWhitespace_ReturnsEmpty()
+    {
+        Prop.ForAll<string?>(value =>
+                {
+                    if (!string.IsNullOrWhiteSpace(value))
+                        return true;
+
+                    IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(value);
+                    return tokens.Count == 0;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Tokenize_SingleWord_ReturnsSingleToken()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || value.Any(char.IsWhiteSpace) || value.Contains('"'))
+                    return true;
+
+                IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(value);
+                return tokens.Count == 1 && tokens[0] == value;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Tokenize_SpaceSeparatedWords_ProducesCorrectCount()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || value.Any(char.IsWhiteSpace) || value.Contains('"'))
+                    return true;
+
+                string[] parts = value.Split(' ');
+                int expectedCount = parts.Count(p => p.Length > 0);
+                if (expectedCount < 2)
+                    return true;
+
+                IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(value);
+                return tokens.Count == expectedCount;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Tokenize_QuotedSpan_PreservesInternalContent()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || value.Contains('"'))
+                    return true;
+
+                string input = "\"" + value + "\"";
+                IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(input);
+                return tokens.Count == 1 && tokens[0] == value;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Tokenize_DoubleQuoteInsideQuotes_ProducesLiteralQuote()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || value.Contains('"'))
+                    return true;
+
+                string input = "\"hello\"\"world\"";
+                IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(input);
+                return tokens.Count == 1 && tokens[0] == "hello\"world";
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Tokenize_NoTokensAreEmpty()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    return true;
+
+                IReadOnlyList<string> tokens = ArgumentTokenizer.Tokenize(value);
+
+                foreach (string token in tokens)
+                {
+                    if (string.IsNullOrEmpty(token))
+                        return false;
+                }
+
+                return true;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/CliInvoke.Tests/Fuzzing/ArgumentsSpecFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ArgumentsSpecFuzzTests.cs
@@ -102,15 +102,7 @@ public class ArgumentsSpecFuzzTests
     {
         var spec = new ArgumentsSpec();
 
-        try
-        {
-            spec.AddEnumerable(Enumerable.Empty<string>(), escape: false);
-            return;
-        }
-        catch (ArgumentException)
-        {
-            await Assert.That(true).IsTrue();
-        }
+        await Assert.That(() => spec.AddEnumerable(Enumerable.Empty<string>(), escape: false)).Throws<ArgumentException>();
     }
 
     [Test]
@@ -118,15 +110,7 @@ public class ArgumentsSpecFuzzTests
     {
         var spec = new ArgumentsSpec();
 
-        try
-        {
-            spec.Add((string)null!, escape: false);
-            return;
-        }
-        catch (ArgumentNullException)
-        {
-            await Assert.That(true).IsTrue();
-        }
+        await Assert.That(() => spec.Add((string)null!, escape: false)).Throws<ArgumentNullException>();
     }
 
     [Test]

--- a/tests/CliInvoke.Tests/Fuzzing/ArgumentsSpecFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ArgumentsSpecFuzzTests.cs
@@ -1,0 +1,148 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Linq;
+using CliInvoke.Core.Configuration;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="ArgumentsSpec"/>.
+/// </summary>
+public class ArgumentsSpecFuzzTests
+{
+    [Test]
+    public void Add_ThenBuild_AlwaysProducesNonNullOutput()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
+                    return true;
+
+                string result = new ArgumentsSpec()
+                    .Add(value, escape: false)
+                    .Build();
+
+                return !string.IsNullOrEmpty(result);
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Add_WithEscape_ProducesNonNullOutput()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
+                    return true;
+
+                string result = new ArgumentsSpec()
+                    .Add(value, escape: true)
+                    .Build();
+
+                return !string.IsNullOrEmpty(result);
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void AddMultiple_ThenBuild_ProducesSpaceSeparatedOutput()
+    {
+        Prop.ForAll<string, string>((a, b) =>
+            {
+                if (string.IsNullOrEmpty(a) || a.Contains(' ') || a.Contains('"') || a.Contains('\n') ||
+                    string.IsNullOrEmpty(b) || b.Contains(' ') || b.Contains('"') || b.Contains('\n'))
+                    return true;
+
+                string result = new ArgumentsSpec()
+                    .Add(a, escape: false)
+                    .Add(b, escape: false)
+                    .Build();
+
+                return result.Contains(' ');
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Add_WithValidationPredicate_RejectsInvalidArguments()
+    {
+        Func<string, bool> rejectAll = _ => false;
+
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value))
+                    return true;
+
+                var spec = new ArgumentsSpec(rejectAll);
+
+                try
+                {
+                    spec.Add(value, escape: false);
+                    return false;
+                }
+                catch (ArgumentException)
+                {
+                    return true;
+                }
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public async Task AddEnumerable_WithEmptyValues_ThrowsArgumentException()
+    {
+        var spec = new ArgumentsSpec();
+
+        try
+        {
+            spec.AddEnumerable(Enumerable.Empty<string>(), escape: false);
+            return;
+        }
+        catch (ArgumentException)
+        {
+            await Assert.That(true).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Add_NullValue_ThrowsArgumentNullException()
+    {
+        var spec = new ArgumentsSpec();
+
+        try
+        {
+            spec.Add((string)null!, escape: false);
+            return;
+        }
+        catch (ArgumentNullException)
+        {
+            await Assert.That(true).IsTrue();
+        }
+    }
+
+    [Test]
+    public void Clear_ResetsBuffer()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value))
+                    return true;
+
+                var spec = new ArgumentsSpec();
+                spec.Add(value, escape: false);
+                spec.Clear();
+                string result = spec.Build();
+                return result == string.Empty;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/CliInvoke.Tests/Fuzzing/ProcessResourcePolicyFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ProcessResourcePolicyFuzzTests.cs
@@ -1,0 +1,158 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using CliInvoke.Core.Configuration;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="ProcessResourcePolicySpec"/>.
+/// </summary>
+public class ProcessResourcePolicyFuzzTests
+{
+    [Test]
+    public void SetMinWorkingSet_GreaterThanMax_ThrowsArgumentOutOfRangeException()
+    {
+        Prop.ForAll<int>(min =>
+                {
+                    if (min <= 1 || min > nint.MaxValue / 2) return true;
+
+                    var spec = new ProcessResourcePolicySpec();
+                    spec.SetMaxWorkingSet((nint)(min - 1));
+
+                    try
+                    {
+                        spec.SetMinWorkingSet((nint)min);
+                        return false;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        return true;
+                    }
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void SetMaxWorkingSet_LessThanMin_ThrowsArgumentOutOfRangeException()
+    {
+        Prop.ForAll<int>(max =>
+                {
+                    if (max <= 1) return true;
+
+                    var spec = new ProcessResourcePolicySpec();
+                    spec.SetMinWorkingSet((nint)(max + 1));
+
+                    try
+                    {
+                        spec.SetMaxWorkingSet((nint)max);
+                        return false;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        return true;
+                    }
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void SetMinWorkingSet_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        Prop.ForAll<int>(value =>
+                {
+                    if (value >= 0) return true;
+
+                    var spec = new ProcessResourcePolicySpec();
+
+                    try
+                    {
+                        spec.SetMinWorkingSet((nint)value);
+                        return false;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        return true;
+                    }
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void SetMaxWorkingSet_Negative_ThrowsArgumentOutOfRangeException()
+    {
+        Prop.ForAll<int>(value =>
+                {
+                    if (value >= 0) return true;
+
+                    var spec = new ProcessResourcePolicySpec();
+
+                    try
+                    {
+                        spec.SetMaxWorkingSet((nint)value);
+                        return false;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        return true;
+                    }
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public async Task SetMaxWorkingSet_Zero_ThrowsArgumentOutOfRangeException()
+    {
+        var spec = new ProcessResourcePolicySpec();
+
+        try
+        {
+            spec.SetMaxWorkingSet(0);
+            return;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            await Assert.That(true).IsTrue();
+        }
+    }
+
+    [Test]
+    public void Build_WithValidMinAndMax_ReturnsPolicyWithCorrectValues()
+    {
+        Prop.ForAll<int, int>((min, max) =>
+                {
+                    if (min < 1 || max <= min || max > 100_000_000)
+                        return true;
+
+                    var spec = new ProcessResourcePolicySpec();
+                    spec.SetMinWorkingSet((nint)min);
+                    spec.SetMaxWorkingSet((nint)max);
+
+                    var policy = spec.Build();
+
+                    return policy.MinWorkingSet == (nint)min &&
+                           policy.MaxWorkingSet == (nint)max;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public async Task Build_DefaultSpec_HasExpectedDefaults()
+    {
+        var spec = new ProcessResourcePolicySpec();
+        var policy = spec.Build();
+
+        await Assert.That(policy.MinWorkingSet).IsNull();
+        await Assert.That(policy.MaxWorkingSet).IsNull();
+        await Assert.That(policy.PriorityClass).IsEqualTo(ProcessPriorityClass.Normal);
+        await Assert.That(policy.EnablePriorityBoost).IsFalse();
+    }
+}

--- a/tests/CliInvoke.Tests/Fuzzing/ProcessResourcePolicyFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ProcessResourcePolicyFuzzTests.cs
@@ -46,7 +46,7 @@ public class ProcessResourcePolicyFuzzTests
     {
         Prop.ForAll<int>(max =>
                 {
-                    if (max <= 1) return true;
+                    if (max <= 1 || max >= int.MaxValue - 1) return true;
 
                     var spec = new ProcessResourcePolicySpec();
                     spec.SetMinWorkingSet((nint)(max + 1));

--- a/tests/CliInvoke.Tests/Fuzzing/ProcessResourcePolicyFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ProcessResourcePolicyFuzzTests.cs
@@ -113,15 +113,7 @@ public class ProcessResourcePolicyFuzzTests
     {
         var spec = new ProcessResourcePolicySpec();
 
-        try
-        {
-            spec.SetMaxWorkingSet(0);
-            return;
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            await Assert.That(true).IsTrue();
-        }
+        await Assert.That(() => spec.SetMaxWorkingSet(0)).Throws<ArgumentOutOfRangeException>();
     }
 
     [Test]

--- a/tests/CliInvoke.Tests/Fuzzing/ProcessTimeoutPolicyFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ProcessTimeoutPolicyFuzzTests.cs
@@ -55,7 +55,7 @@ public class ProcessTimeoutPolicyFuzzTests
     {
         Prop.ForAll<int>(milliseconds =>
                 {
-                    if (milliseconds < 1) return true;
+                    if (milliseconds < 1 || milliseconds >= int.MaxValue - 1) return true;
 
                     var a = new ProcessTimeoutPolicy(
                         TimeSpan.FromMilliseconds(milliseconds),
@@ -163,7 +163,7 @@ public class ProcessTimeoutPolicyFuzzTests
     {
         Prop.ForAll<int>(milliseconds =>
                 {
-                    if (milliseconds < 1) return true;
+                    if (milliseconds < 1 || milliseconds >= int.MaxValue - 1) return true;
 
                     var a = new ProcessTimeoutPolicy(
                         TimeSpan.FromMilliseconds(milliseconds),

--- a/tests/CliInvoke.Tests/Fuzzing/ProcessTimeoutPolicyFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ProcessTimeoutPolicyFuzzTests.cs
@@ -1,0 +1,211 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="ProcessTimeoutPolicy"/>.
+/// </summary>
+public class ProcessTimeoutPolicyFuzzTests
+{
+    [Test]
+    public void Equals_IsReflexive()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var policy = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds),
+                        enabled: true,
+                        ProcessExitBehaviour.GracefulExit);
+
+                    return policy.Equals(policy);
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Equals_SameValues_ReturnsTrue()
+    {
+        Prop.ForAll<int, bool>((milliseconds, enabled) =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var ts = TimeSpan.FromMilliseconds(milliseconds);
+                    var a = new ProcessTimeoutPolicy(ts, enabled, ProcessExitBehaviour.GracefulExit);
+                    var b = new ProcessTimeoutPolicy(ts, enabled, ProcessExitBehaviour.GracefulExit);
+
+                    return a.Equals(b) && b.Equals(a);
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Equals_DifferentValues_ReturnsFalse()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 1) return true;
+
+                    var a = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds),
+                        enabled: true,
+                        ProcessExitBehaviour.GracefulExit);
+
+                    var b = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds + 1),
+                        enabled: true,
+                        ProcessExitBehaviour.GracefulExit);
+
+                    return !a.Equals(b);
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Equals_Null_ReturnsFalse()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var policy = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds),
+                        enabled: true);
+
+                    return !policy.Equals(null);
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GetHashCode_ConsistentWithEquals()
+    {
+        Prop.ForAll<int, bool>((milliseconds, enabled) =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var ts = TimeSpan.FromMilliseconds(milliseconds);
+                    var a = new ProcessTimeoutPolicy(ts, enabled, ProcessExitBehaviour.GracefulExit);
+                    var b = new ProcessTimeoutPolicy(ts, enabled, ProcessExitBehaviour.GracefulExit);
+
+                    return a.Equals(b) && a.GetHashCode() == b.GetHashCode();
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void Constructor_NegativeTimeSpan_ThrowsArgumentOutOfRangeException()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds >= 0) return true;
+
+                    try
+                    {
+                        new ProcessTimeoutPolicy(
+                            TimeSpan.FromMilliseconds(milliseconds),
+                            enabled: true);
+                        return false;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        return true;
+                    }
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void FromTimeSpan_PreservesThreshold()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var policy = ProcessTimeoutPolicy.FromTimeSpan(
+                        TimeSpan.FromMilliseconds(milliseconds));
+
+                    return policy.TimeoutThreshold == TimeSpan.FromMilliseconds(milliseconds) &&
+                           policy.Enabled;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void OperatorEquals_Symmetric()
+    {
+        Prop.ForAll<int, bool>((milliseconds, enabled) =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var ts = TimeSpan.FromMilliseconds(milliseconds);
+                    var a = new ProcessTimeoutPolicy(ts, enabled, ProcessExitBehaviour.GracefulExit);
+                    var b = new ProcessTimeoutPolicy(ts, enabled, ProcessExitBehaviour.GracefulExit);
+
+                    return (a == b) && (b == a);
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void OperatorNotEquals_DifferentValues_ReturnsTrue()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 1) return true;
+
+                    var a = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds),
+                        enabled: true);
+                    var b = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds + 1),
+                        enabled: true);
+
+                    return a != b;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void OperatorGreaterThan_NonNullVsNull_ReturnsTrue()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var policy = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds),
+                        enabled: true);
+
+                    return policy > null;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void OperatorLessThan_NullVsNonNull_ReturnsTrue()
+    {
+        Prop.ForAll<int>(milliseconds =>
+                {
+                    if (milliseconds < 0) return true;
+
+                    var policy = new ProcessTimeoutPolicy(
+                        TimeSpan.FromMilliseconds(milliseconds),
+                        enabled: true);
+
+                    return null < policy;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/CliInvoke.Tests/Fuzzing/ShellArgumentEscaperFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ShellArgumentEscaperFuzzTests.cs
@@ -1,0 +1,113 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Linq;
+using CliInvoke.Core.Internal;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="ShellArgumentEscaper"/>.
+/// </summary>
+public class ShellArgumentEscaperFuzzTests
+{
+    private static readonly char[] PowerShellMetacharacters =
+        ['`', '$', ';', '|', '&', '(', ')', '{', '}', '<', '>', '"', '\''];
+
+    private static readonly char[] CmdMetacharacters =
+        ['^', '&', '|', '<', '>', '%'];
+
+    [Test]
+    public void EscapeForPowerShell_NullOrEmpty_ReturnsEmpty()
+    {
+        Prop.ForAll<string?>(value =>
+                {
+                    if (value is not null and { Length: > 0 })
+                        return true;
+
+                    string result = ShellArgumentEscaper.EscapeForPowerShell(value);
+                    return result == string.Empty;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeForPowerShell_OutputContainsNoUnescapedMetacharacters()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
+                    return true;
+
+                string escaped = ShellArgumentEscaper.EscapeForPowerShell(value);
+                return escaped.Length >= value.Length;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeForPowerShell_NonSpecialCharactersPassThroughUnchanged()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) ||
+                    Enumerable.Any(value, c => char.IsControl(c) || Array.IndexOf(PowerShellMetacharacters, c) >= 0))
+                    return true;
+
+                string escaped = ShellArgumentEscaper.EscapeForPowerShell(value);
+                return escaped == value;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeForCmd_NullOrEmpty_ReturnsEmpty()
+    {
+        Prop.ForAll<string?>(value =>
+                {
+                    if (value is not null and { Length: > 0 })
+                        return true;
+
+                    string result = ShellArgumentEscaper.EscapeForCmd(value);
+                    return result == string.Empty;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeForCmd_OutputContainsNoUnescapedMetacharacters()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
+                    return true;
+
+                string escaped = ShellArgumentEscaper.EscapeForCmd(value);
+                return escaped.Length >= value.Length;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void EscapeForCmd_NonSpecialCharactersPassThroughUnchanged()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) ||
+                    Enumerable.Any(value, c => char.IsControl(c) || Array.IndexOf(CmdMetacharacters, c) >= 0 || c == '"'))
+                    return true;
+
+                string escaped = ShellArgumentEscaper.EscapeForCmd(value);
+                return escaped == value;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/CliInvoke.Tests/Fuzzing/ShellArgumentEscaperFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ShellArgumentEscaperFuzzTests.cs
@@ -46,22 +46,24 @@ public class ShellArgumentEscaperFuzzTests
             {
                 if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
                     return true;
- 
+
                 string escaped = ShellArgumentEscaper.EscapeForPowerShell(value);
- 
-                // Verify each PowerShell metacharacter is properly escaped
-                foreach (char metachar in PowerShellMetacharacters)
+
+                // Build expected output character-by-character, mirroring the escaper logic
+                var expected = new System.Text.StringBuilder(value.Length + 16);
+                foreach (char c in value)
                 {
-                    if (value.Contains(metachar))
+                    if (Array.IndexOf(PowerShellMetacharacters, c) >= 0)
                     {
-                        // The escaped sequence should be backtick followed by the metachar
-                        string expectedEscaped = $"`{metachar}";
-                        if (!escaped.Contains(expectedEscaped))
-                            return false;
+                        expected.Append('`').Append(c);
+                    }
+                    else
+                    {
+                        expected.Append(c);
                     }
                 }
- 
-                return true;
+
+                return escaped == expected.ToString();
             })
             .QuickCheckThrowOnFailure();
     }
@@ -102,29 +104,28 @@ public class ShellArgumentEscaperFuzzTests
             {
                 if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
                     return true;
- 
+
                 string escaped = ShellArgumentEscaper.EscapeForCmd(value);
- 
-                // Verify each CMD metacharacter is properly escaped
-                foreach (char metachar in CmdMetacharacters)
+
+                // Build expected output character-by-character, mirroring the escaper logic
+                var expected = new System.Text.StringBuilder(value.Length + 16);
+                foreach (char c in value)
                 {
-                    if (value.Contains(metachar))
+                    if (Array.IndexOf(CmdMetacharacters, c) >= 0)
                     {
-                        // The escaped sequence should be caret followed by the metachar
-                        string expectedEscaped = $"^{metachar}";
-                        if (!escaped.Contains(expectedEscaped))
-                            return false;
+                        expected.Append('^').Append(c);
+                    }
+                    else if (c == '"')
+                    {
+                        expected.Append("\"\"");
+                    }
+                    else
+                    {
+                        expected.Append(c);
                     }
                 }
- 
-                // Also check for double-quoted escape of double quotes
-                if (value.Contains('"'))
-                {
-                    if (!escaped.Contains("\"\""))
-                        return false;
-                }
- 
-                return true;
+
+                return escaped == expected.ToString();
             })
             .QuickCheckThrowOnFailure();
     }

--- a/tests/CliInvoke.Tests/Fuzzing/ShellArgumentEscaperFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/ShellArgumentEscaperFuzzTests.cs
@@ -46,9 +46,22 @@ public class ShellArgumentEscaperFuzzTests
             {
                 if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
                     return true;
-
+ 
                 string escaped = ShellArgumentEscaper.EscapeForPowerShell(value);
-                return escaped.Length >= value.Length;
+ 
+                // Verify each PowerShell metacharacter is properly escaped
+                foreach (char metachar in PowerShellMetacharacters)
+                {
+                    if (value.Contains(metachar))
+                    {
+                        // The escaped sequence should be backtick followed by the metachar
+                        string expectedEscaped = $"`{metachar}";
+                        if (!escaped.Contains(expectedEscaped))
+                            return false;
+                    }
+                }
+ 
+                return true;
             })
             .QuickCheckThrowOnFailure();
     }
@@ -89,9 +102,29 @@ public class ShellArgumentEscaperFuzzTests
             {
                 if (string.IsNullOrEmpty(value) || value.Contains('\n') || value.Contains('\r'))
                     return true;
-
+ 
                 string escaped = ShellArgumentEscaper.EscapeForCmd(value);
-                return escaped.Length >= value.Length;
+ 
+                // Verify each CMD metacharacter is properly escaped
+                foreach (char metachar in CmdMetacharacters)
+                {
+                    if (value.Contains(metachar))
+                    {
+                        // The escaped sequence should be caret followed by the metachar
+                        string expectedEscaped = $"^{metachar}";
+                        if (!escaped.Contains(expectedEscaped))
+                            return false;
+                    }
+                }
+ 
+                // Also check for double-quoted escape of double quotes
+                if (value.Contains('"'))
+                {
+                    if (!escaped.Contains("\"\""))
+                        return false;
+                }
+ 
+                return true;
             })
             .QuickCheckThrowOnFailure();
     }

--- a/tests/CliInvoke.Tests/Fuzzing/VersionParseExtensionsFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/VersionParseExtensionsFuzzTests.cs
@@ -44,15 +44,8 @@ public class VersionParseExtensionsFuzzTests
                 if (string.IsNullOrWhiteSpace(value) || !Enumerable.Any(value, char.IsDigit))
                     return true;
 
-                try
-                {
-                    Version result = Version.GracefulParse(value);
-                    return result.Major >= 0;
-                }
-                catch (ArgumentException)
-                {
-                    return true;
-                }
+                Version result = Version.GracefulParse(value);
+                return result.Major >= 0 && result.Minor >= 0;
             })
             .QuickCheckThrowOnFailure();
     }
@@ -149,8 +142,36 @@ public class VersionParseExtensionsFuzzTests
 
                 Version result = Version.GracefulParse(value);
 
+                // Parse each segment and compare with parsed components
+                if (!int.TryParse(segments[0], out int expectedMajor))
+                    return true;
+
+                if (result.Major != expectedMajor)
+                    return false;
+
                 if (segments.Length >= 2)
-                    return result.Minor >= 0;
+                {
+                    if (!int.TryParse(segments[1], out int expectedMinor))
+                        return true;
+                    if (result.Minor != expectedMinor)
+                        return false;
+                }
+
+                if (segments.Length >= 3)
+                {
+                    if (!int.TryParse(segments[2], out int expectedBuild))
+                        return true;
+                    if (result.Build != expectedBuild)
+                        return false;
+                }
+
+                if (segments.Length >= 4)
+                {
+                    if (!int.TryParse(segments[3], out int expectedRevision))
+                        return true;
+                    if (result.Revision != expectedRevision)
+                        return false;
+                }
 
                 return true;
             })

--- a/tests/CliInvoke.Tests/Fuzzing/VersionParseExtensionsFuzzTests.cs
+++ b/tests/CliInvoke.Tests/Fuzzing/VersionParseExtensionsFuzzTests.cs
@@ -1,0 +1,159 @@
+/*
+    CliInvoke.Tests
+    Copyright (C) 2024-2026  Alastair Lundy
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using System.Linq;
+using CliInvoke.Internal.Versions;
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace CliInvoke.Tests.Fuzzing;
+
+/// <summary>
+///     Property-based fuzz tests for <see cref="VersionParseExtensions"/>.
+/// </summary>
+public class VersionParseExtensionsFuzzTests
+{
+    [Test]
+    public void GracefulParse_StandardDigitDotFormat_ReturnsValidVersion()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) ||
+                    !Enumerable.All(value, c => char.IsDigit(c) || c == '.') ||
+                    value.Split('.', StringSplitOptions.RemoveEmptyEntries).Length < 1 ||
+                    Enumerable.Any(value.Split('.', StringSplitOptions.RemoveEmptyEntries), seg => seg.Length == 0))
+                    return true;
+
+                Version result = Version.GracefulParse(value);
+                return result.Major >= 0;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GracefulParse_WithDigitContent_ReturnsNonNegativeMajor()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || !Enumerable.Any(value, char.IsDigit))
+                    return true;
+
+                try
+                {
+                    Version result = Version.GracefulParse(value);
+                    return result.Major >= 0;
+                }
+                catch (ArgumentException)
+                {
+                    return true;
+                }
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GracefulParse_NoDigits_ThrowsArgumentException()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || Enumerable.Any(value, char.IsDigit))
+                    return true;
+
+                try
+                {
+                    Version.GracefulParse(value);
+                    return false;
+                }
+                catch (ArgumentException)
+                {
+                    return true;
+                }
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GracefulParse_NullOrEmpty_ThrowsArgumentException()
+    {
+        Prop.ForAll<string?>(value =>
+                {
+                    if (value is not null and { Length: > 0 })
+                        return true;
+
+                    try
+                    {
+                        Version.GracefulParse(value!);
+                        return false;
+                    }
+                    catch (ArgumentException)
+                    {
+                        return true;
+                    }
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GracefulParse_WhitespaceOnly_ThrowsArgumentException()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrEmpty(value) || !string.IsNullOrWhiteSpace(value))
+                    return true;
+
+                try
+                {
+                    Version.GracefulParse(value);
+                    return false;
+                }
+                catch (ArgumentException)
+                {
+                    return true;
+                }
+            })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GracefulParse_SingleDigit_ReturnsVersionWithZeroMinor()
+    {
+        Prop.ForAll<char>(c =>
+                {
+                    if (!char.IsDigit(c))
+                        return true;
+
+                    Version result = Version.GracefulParse(c.ToString());
+                    return result.Major == c - '0' && result.Minor == 0;
+                })
+            .QuickCheckThrowOnFailure();
+    }
+
+    [Test]
+    public void GracefulParse_DotSeparatedDigits_ProducesCorrectComponentCount()
+    {
+        Prop.ForAll<string>(value =>
+            {
+                if (string.IsNullOrWhiteSpace(value) || value.Length > 20 ||
+                    !Enumerable.All(value, c => char.IsDigit(c) || c == '.'))
+                    return true;
+
+                string[] segments = value.Split('.', StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length < 2 || segments.Length > 4 || Enumerable.Any(segments, seg => seg.Length == 0))
+                    return true;
+
+                Version result = Version.GracefulParse(value);
+
+                if (segments.Length >= 2)
+                    return result.Minor >= 0;
+
+                return true;
+            })
+            .QuickCheckThrowOnFailure();
+    }
+}

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="TUnit" Version="1.55.2" />
     <PackageVersion Include="DotExtensions" Version="10.3.3" />
+    <PackageVersion Include="FsCheck" Version="3.4.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds FsCheck 3.4.0 property-based testing to address GitHub Code Scanning alert #15 (project is not fuzzed).

7 new fuzz test files covering security-critical escapers, tokenizer, builders, and policy classes. All 395 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added property-based fuzz testing for argument escaping and tokenization, shell escaping, argument specifications, process resource policies, timeout policies, and version parsing.
  - Expanded coverage for edge cases, invalid inputs, exception handling, default values, equality behavior, escaping rules, and output consistency.
  - Added centrally managed FsCheck test support for more consistent and thorough validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->